### PR TITLE
Implement script to reset database and create tables

### DIFF
--- a/infra/queries/drop-schema-and-populate-tables.sql
+++ b/infra/queries/drop-schema-and-populate-tables.sql
@@ -1,0 +1,87 @@
+DROP SCHEMA IF EXISTS public CASCADE;
+
+CREATE SCHEMA public;
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+CREATE TYPE ROLES AS ENUM ('ADMIN', 'USER');
+
+CREATE TABLE users (
+  id UUID DEFAULT uuid_generate_v4() CONSTRAINT users_pkey PRIMARY KEY,
+  email VARCHAR(100) UNIQUE NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  user_name VARCHAR(50) UNIQUE NOT NULL,
+  password VARCHAR(255) NOT NULL,
+  user_role ROLES DEFAULT('USER'),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE reset_password_tokens (
+  user_id UUID NOT NULL,
+  reset_token VARCHAR(255) NOT NULL,
+  used BOOLEAN DEFAULT FALSE,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT reset_password_tokens_pkey PRIMARY KEY (user_id, reset_token),
+  FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+CREATE TABLE restaurants (
+  id UUID DEFAULT uuid_generate_v4() CONSTRAINT restaurants_pkey PRIMARY KEY,
+  name VARCHAR(100) UNIQUE NOT NULL,
+  address VARCHAR(255) NOT NULL,
+  description VARCHAR(255),
+  latitude DOUBLE PRECISION,
+  longitude DOUBLE PRECISION,
+  approved BOOLEAN DEFAULT FALSE,
+  created_by UUID NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+  FOREIGN KEY (created_by) REFERENCES users(id)
+);
+
+CREATE TABLE restaurant_images (
+  id UUID DEFAULT uuid_generate_v4() CONSTRAINT restaurant_images_pkey PRIMARY KEY,
+  restaurant_id UUID NOT NULL,
+  url VARCHAR(255) NOT NULL,
+  description VARCHAR(255),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+  FOREIGN KEY (restaurant_id) REFERENCES restaurants(id)
+);
+
+CREATE TABLE restaurant_likes (
+  id UUID DEFAULT uuid_generate_v4() CONSTRAINT restaurant_likes_pkey PRIMARY KEY,
+  restaurant_id UUID NOT NULL,
+  user_id UUID NOT NULL,
+
+  FOREIGN KEY (restaurant_id) REFERENCES restaurants(id),
+  FOREIGN KEY (user_id) REFERENCES users(id),
+  UNIQUE (restaurant_id, user_id)
+);
+
+CREATE TABLE restaurant_comments (
+  id UUID DEFAULT uuid_generate_v4() CONSTRAINT restaurant_comments_pkey PRIMARY KEY,
+  restaurant_id UUID NOT NULL,
+  user_id UUID NOT NULL,
+  parent_comment_id UUID,
+  description VARCHAR(255),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+  FOREIGN KEY (restaurant_id) REFERENCES restaurants(id),
+  FOREIGN KEY (user_id) REFERENCES users(id),
+  FOREIGN KEY (parent_comment_id) REFERENCES restaurant_comments(id)
+);
+
+CREATE TABLE restaurant_comment_likes (
+  id UUID DEFAULT uuid_generate_v4() CONSTRAINT restaurant_comment_likes_pkey PRIMARY KEY,
+  comment_id UUID NOT NULL,
+  user_id UUID NOT NULL,
+
+  FOREIGN KEY (comment_id) REFERENCES restaurant_comments(id),
+  FOREIGN KEY (user_id) REFERENCES users(id),
+  UNIQUE (comment_id, user_id)
+);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "pnpm services:up && next dev",
+    "dev": "vitest tests/reset-database.test.ts --watch=false && pnpm services:up && next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
@@ -11,7 +11,7 @@
     "services:up": "pnpm docker:compose up -d",
     "services:down": "pnpm docker:compose down",
     "prepare": "husky",
-    "test": "vitest"
+    "test": "vitest --exclude **/tests/reset-database.test.ts"
   },
   "dependencies": {
     "@nextui-org/react": "^2.4.0",

--- a/tests/orchestrator.ts
+++ b/tests/orchestrator.ts
@@ -1,0 +1,25 @@
+import { readdirSync, readFileSync } from 'fs';
+import { resolve } from 'path';
+
+import { database } from '../infra/database';
+
+export const orchestrator = Object.freeze({
+  resetDatabase,
+});
+
+async function resetDatabase() {
+  const queriesFolderPath = resolve('.', 'infra', 'queries');
+  const queries = readdirSync(queriesFolderPath, {
+    encoding: 'utf-8',
+  });
+
+  const resetDatabaseQueryFileName = queries[0];
+
+  const resetDatabaseQuery = readFileSync(
+    resolve(queriesFolderPath, resetDatabaseQueryFileName),
+    { encoding: 'utf-8' },
+  );
+
+  const client = database.getClient();
+  await client.query(resetDatabaseQuery);
+}

--- a/tests/reset-database.test.ts
+++ b/tests/reset-database.test.ts
@@ -1,0 +1,6 @@
+import { orchestrator } from './orchestrator';
+
+test('Dropping public schema and Creating tables', async () => {
+  await orchestrator.resetDatabase();
+  expect(true).toBe(true);
+});


### PR DESCRIPTION
- This PR was made by following the description of #13.

It was done a script to read a specific file content (that contains the query to reset database) and some adjustments in the vitest commands (`dev` and `test`)

## Important:
- Now, when run `pnpm dev` the script to reset the database is executed.
- When run `pnpm test` the script to reset database is ignored.

resolve #13 