### PR TITLE
[`/auth/signin`]: Integrate `signIn` functionality with frontend and create middleware

### DIFF
--- a/models/authentication.ts
+++ b/models/authentication.ts
@@ -9,7 +9,7 @@ import { SignInProps, SignUpProps } from '@/types';
 
 type FailureAuthResponse = {
   message: string;
-  fields: Array<AvailableSignUpFields>;
+  fields: Array<AvailableSignUpFields | AvailableSignInFields>;
 };
 
 type SuccessAuthSignUpResponse = {
@@ -19,6 +19,7 @@ type SuccessAuthSignUpResponse = {
 };
 
 export type AvailableSignUpFields = keyof SignUpProps;
+export type AvailableSignInFields = keyof SignInProps;
 
 export const auth = Object.freeze({
   signIn,
@@ -136,7 +137,7 @@ const signInSchema = z.object({
   }),
 });
 
-type SignInResponse =
+export type SignInResponse =
   | Failure<FailureAuthResponse>
   | Success<{
       accessToken: string;

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -1,7 +1,18 @@
+import { cookies } from 'next/headers';
 import Link from 'next/link';
+import { redirect } from 'next/navigation';
 
+import { createAuthenticationDataSource } from '@/data/authentication';
+import {
+  auth,
+  AvailableSignInFields,
+  SignInResponse,
+} from '@/models/authentication';
 import { Input } from '@/src/components/Input';
 import { SubmitButton } from '@/src/components/SubmitButton';
+import { constants } from '@/src/utils/constants';
+import { form } from '@/src/utils/form';
+import { SignInProps } from '@/types';
 
 type Props = {
   searchParams: {
@@ -9,8 +20,41 @@ type Props = {
   };
 };
 
+let signInResponse: SignInResponse;
+
+async function signInAction(formData: FormData) {
+  'use server';
+
+  const sanitizedData = form.sanitizeData<SignInProps>(formData);
+
+  const authDataSource = createAuthenticationDataSource();
+  signInResponse = await auth.signIn(authDataSource, sanitizedData);
+
+  if (signInResponse.data) {
+    const { accessToken } = signInResponse.data;
+
+    const sevenDaysInMilliseconds = 60 * 60 * 24 * 7 * 1000;
+
+    cookies().set(constants.accessTokenKey, accessToken, {
+      expires: new Date(Date.now() + sevenDaysInMilliseconds),
+      httpOnly: true,
+    });
+  }
+
+  return redirect('/dashboard');
+}
+
 export default function Page({ searchParams }: Props) {
   const { userName } = searchParams;
+
+  function setInputError(inputName: AvailableSignInFields) {
+    if (!signInResponse?.error) return '';
+
+    const { fields, message } = signInResponse.error;
+    const inputHasError = fields.includes(inputName);
+
+    return inputHasError ? message : '';
+  }
 
   return (
     <div className="space-y-4">
@@ -23,9 +67,22 @@ export default function Page({ searchParams }: Props) {
         </Link>
       </p>
 
-      <form className="flex flex-col gap-2">
-        <Input id="email" label="Email*" required />
-        <Input id="password" label="Senha*" type="password" required />
+      <form action={signInAction} className="flex flex-col gap-2">
+        <Input
+          id="email"
+          name="email"
+          label="Email*"
+          required
+          error={setInputError('email')}
+        />
+        <Input
+          id="password"
+          name="password"
+          label="Senha*"
+          type="password"
+          required
+          error={setInputError('password')}
+        />
         <SubmitButton>Entrar</SubmitButton>
       </form>
     </div>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,8 +1,28 @@
+import { Button } from '@nextui-org/react';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+
+import { constants } from '@/src/utils/constants';
+
+async function signOut() {
+  'use server';
+
+  cookies().delete(constants.accessTokenKey);
+
+  return redirect('/auth/signin');
+}
+
 export default function Page() {
+  // TODO: validate accessToken integrity
+
   return (
     <div>
       <h1>Dashboard</h1>
       <p>Essa é a página do dashboard</p>
+
+      <form action={signOut}>
+        <Button type="submit">Sair</Button>
+      </form>
     </div>
   );
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { constants } from './utils/constants';
+
+export function middleware(request: NextRequest) {
+  const accessToken = request.cookies.get(constants.accessTokenKey)?.value;
+  const { pathname } = request.nextUrl;
+
+  const isPublicPath = pathname.startsWith('/auth');
+  const isPrivatePath = pathname.startsWith('/dashboard');
+
+  if (!accessToken && isPrivatePath) {
+    return NextResponse.redirect(new URL('/auth/signin', request.url));
+  }
+
+  if (accessToken && isPublicPath) {
+    return NextResponse.redirect(new URL('/dashboard', request.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)', '/auth'],
+};

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,3 +1,4 @@
 export const constants = {
   themeKey: 'onde-ir:theme',
+  accessTokenKey: 'onde-ir:accessToken',
 };


### PR DESCRIPTION
- This PR implements the issue #46, and also creates a `middleware.ts` file to handle users access between public/private pages.

resolve #46

## Tasks to be done
- verify accessToken and fetch user data in `/dashboard`.