### PR TITLE
Fix warning caused by `tsconfig` mistake

### DIFF
--- a/tests/models/auth.test.ts
+++ b/tests/models/auth.test.ts
@@ -1,8 +1,8 @@
-import { createAuthenticationDataSource } from '../../data/authentication';
-import { database } from '../../infra/database';
-import { auth } from '../../models/authentication';
-import { SignInProps, SignUpProps } from '../../types';
-import { orchestrator } from '../orchestrator';
+import { createAuthenticationDataSource } from '@/data/authentication';
+import { database } from '@/infra/database';
+import { auth } from '@/models/authentication';
+import { orchestrator } from '@/tests/orchestrator';
+import { SignInProps, SignUpProps } from '@/types';
 
 beforeAll(async () => {
   await orchestrator.resetDatabase();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,8 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./*"],
-    }
+    },
+    "types": ["vitest/globals"]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "jest.config.js"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
- This PR adjusts `tsconfig.json` file to use vitest `global` config.


The mistake occured in the following PR:
- https://github.com/SouzaGabriel26/onde-ir/pull/48