### PR TITLE
[`test/models/user`]: create tests for `models/user`

### DIFF
--- a/infra/database.ts
+++ b/infra/database.ts
@@ -69,4 +69,5 @@ function getPool() {
 async function endAllPools() {
   const endAllPoolsPromises = pools.map((pool) => pool.end());
   await Promise.all(endAllPoolsPromises);
+  pools.length = 0;
 }

--- a/models/user.ts
+++ b/models/user.ts
@@ -16,7 +16,7 @@ type FindByIdInput = {
 const findByIdSchema = z.object({
   id: z
     .string({
-      required_error: 'A proprietade "id" é obrigatória',
+      required_error: 'A propriedade "id" é obrigatória',
       invalid_type_error: 'A propriedade "id" deve ser uma string',
     })
     .uuid({

--- a/tests/infra/database.test.ts
+++ b/tests/infra/database.test.ts
@@ -1,4 +1,9 @@
-import { database } from '../../infra/database';
+import { database } from '@/infra/database';
+import { orchestrator } from '@/tests/orchestrator';
+
+beforeAll(async () => {
+  await orchestrator.resetDatabase();
+});
 
 afterAll(async () => {
   await database.endAllPools();

--- a/tests/models/auth.test.ts
+++ b/tests/models/auth.test.ts
@@ -322,6 +322,7 @@ describe('> models/authentication', () => {
 
       expect(result.data?.accessToken.split('.').length).toBe(3);
     });
+
     test('Providing email without following the pattern', async () => {
       const authDataSource = createAuthenticationDataSource();
       const result = await auth.signIn(authDataSource, {

--- a/tests/models/user.test.ts
+++ b/tests/models/user.test.ts
@@ -1,0 +1,179 @@
+import { createUserDataSource } from '@/data/user';
+import { database } from '@/infra/database';
+import { user } from '@/models/user';
+import { sql } from '@/src/utils/syntax-highlighting';
+import { orchestrator } from '@/tests/orchestrator';
+
+beforeAll(async () => {
+  await orchestrator.resetDatabase();
+});
+
+afterAll(async () => {
+  await database.endAllPools();
+});
+
+describe('> models/user', () => {
+  describe('Invoking "findById" method', () => {
+    test('Providing only a invalid format "id" property', async () => {
+      const invalidId = 'invalid_id';
+
+      const userDataSource = createUserDataSource();
+      const result = await user.findById(userDataSource, {
+        id: invalidId,
+      });
+
+      expect(result).toStrictEqual({
+        data: null,
+        error: {
+          message: 'A propriedade "id" deve ser um UUID',
+        },
+      });
+    });
+
+    test('Providing a valid format "id" property but unexistent', async () => {
+      const unexistentId = '8b9b6e3f-5c1b-4b0d-9c5a-8b9b6e3f5c1b';
+
+      const userDataSource = createUserDataSource();
+      const result = await user.findById(userDataSource, {
+        id: unexistentId,
+      });
+
+      expect(result).toStrictEqual({
+        data: null,
+        error: null,
+      });
+    });
+
+    test('Providing a valid format "id" property and existent', async () => {
+      const userDataSource = createUserDataSource();
+
+      const userIdFromDatabase = await getUserIdFromDatabase();
+
+      const foundUser = await user.findById(userDataSource, {
+        id: userIdFromDatabase,
+      });
+
+      expect(foundUser).toStrictEqual({
+        error: null,
+        data: {
+          id: userIdFromDatabase,
+          email: 'janedoe@email.com',
+          name: 'Jane Doe',
+          userName: 'janeDoe',
+          userRole: 'USER',
+          createdAt: expect.any(String),
+          updatedAt: expect.any(String),
+        },
+      });
+    });
+
+    test('Providing only "id" property as a number', async () => {
+      const numericId = 10 as unknown as string;
+
+      const userDataSource = createUserDataSource();
+      const result = await user.findById(userDataSource, {
+        id: numericId,
+      });
+
+      expect(result).toStrictEqual({
+        data: null,
+        error: {
+          message: 'A propriedade "id" deve ser uma string',
+        },
+      });
+    });
+
+    test('Providing an empty object ("id is required")', async () => {
+      const userDataSource = createUserDataSource();
+
+      const result = await user.findById(userDataSource, {} as any);
+
+      expect(result).toStrictEqual({
+        data: null,
+        error: {
+          message: 'A propriedade "id" é obrigatória',
+        },
+      });
+    });
+
+    test('Providing "select" property as an empty array', async () => {
+      const userDataSource = createUserDataSource();
+
+      const userIdFromDatabase = await getUserIdFromDatabase();
+
+      const foundUser = await user.findById(userDataSource, {
+        id: userIdFromDatabase,
+        select: [],
+      });
+
+      expect(foundUser).toStrictEqual({
+        data: {
+          id: userIdFromDatabase,
+          email: 'janedoe@email.com',
+          name: 'Jane Doe',
+          userName: 'janeDoe',
+          userRole: 'USER',
+          createdAt: expect.any(String),
+          updatedAt: expect.any(String),
+        },
+        error: null,
+      });
+    });
+
+    test('Providing "select" property with "name" and "email" fields', async () => {
+      const userDataSource = createUserDataSource();
+
+      const userIdFromDatabase = await getUserIdFromDatabase();
+
+      const foundUser = await user.findById(userDataSource, {
+        id: userIdFromDatabase,
+        select: ['name', 'email'],
+      });
+
+      expect(foundUser).toStrictEqual({
+        error: null,
+        data: {
+          name: 'Jane Doe',
+          email: 'janedoe@email.com',
+        },
+      });
+    });
+
+    test('Providing "select" property with a invalid field', async () => {
+      const userDataSource = createUserDataSource();
+
+      const userIdFromDatabase = await getUserIdFromDatabase();
+
+      const foundUser = await user.findById(userDataSource, {
+        id: userIdFromDatabase,
+        select: ['email', 'invalid_field'] as any,
+      });
+
+      expect(foundUser).toStrictEqual({
+        data: null,
+        error: {
+          message:
+            'A propriedade "select" deve conter apenas propriedades válidas',
+        },
+      });
+    });
+  });
+});
+
+async function getUserIdFromDatabase() {
+  const client = database.getClient();
+
+  try {
+    console.log('> Running query to get user ID');
+    const query = await client.query(sql`SELECT id FROM users LIMIT 1`);
+    console.log('> Query result:', query);
+
+    if (!query?.rows || query.rows.length === 0) {
+      throw new Error('No users found in the database');
+    }
+
+    return query.rows[0].id;
+  } finally {
+    console.log('> terminou');
+  }
+}


### PR DESCRIPTION
## Context
- In the PR #52, i tried to create tests to `models/user` but it was throwing a error. Today i figure it out.

The error/warning was causing because the tables wasn't creating in the first test file.

In `tests/infra/database.test` it was not a `beforeAll` with the script to reset, create and populate tables.

> Script added to `tests/infra/database.test.ts`:
```ts
beforeAll(async () => {
  await orchestrator.resetDatabase();
});
```

resolve #53