### PR TITLE
[`tests/models/user`]: add `sleep` function to wait dabatase reset

### DIFF
--- a/src/utils/sleep.ts
+++ b/src/utils/sleep.ts
@@ -1,0 +1,3 @@
+export function sleep(ms: number = 500) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/tests/models/user.test.ts
+++ b/tests/models/user.test.ts
@@ -1,10 +1,12 @@
 import { createUserDataSource } from '@/data/user';
 import { database } from '@/infra/database';
 import { user } from '@/models/user';
+import { sleep } from '@/src/utils/sleep';
 import { sql } from '@/src/utils/syntax-highlighting';
 import { orchestrator } from '@/tests/orchestrator';
 
 beforeAll(async () => {
+  await sleep(3000);
   await orchestrator.resetDatabase();
 });
 


### PR DESCRIPTION
- This PR adds a `sleep` function to basically wait for something.

I realized that the test suit `tests/models/user.test.ts` was throwing errors in console:
> preview
[Gravação de tela de 18-06-2024 22:56:23.webm](https://github.com/SouzaGabriel26/onde-ir/assets/66218607/69b4a4a4-7613-42d4-b0b0-113d4d16bde9)

The `beforeAll` wasn't waiting for the script that reset and populate database to complete (`orchestrator.resetTables`).

So i added the `sleep` utils function, which waits 3 seconds before executing `orchestrator.resetTables`.

**OBS:** This was just to stop breaking the tests. I have to investigate further



