### PR TITLE
[`tests`]: Disables `fileParallelism` to not run all tests in parallel

### DIFF
--- a/data/authentication.ts
+++ b/data/authentication.ts
@@ -91,7 +91,7 @@ export function createAuthenticationDataSource() {
         VALUES
           ($1, $2)
       `,
-      values: [input.userId],
+      values: [input.userId, input.resetPasswordToken],
     };
 
     await authenticationPool.query(query);

--- a/src/utils/sleep.ts
+++ b/src/utils/sleep.ts
@@ -1,3 +1,0 @@
-export function sleep(ms: number = 500) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}

--- a/tests/models/auth.test.ts
+++ b/tests/models/auth.test.ts
@@ -510,14 +510,11 @@ describe('> models/authentication', () => {
 
     test('Providing "password" different from "confirmPassword"', async () => {
       const authDataSource = createAuthenticationDataSource();
-      const { data } = await auth.forgetPassword(authDataSource, {
-        email: 'gabriel@email.com',
-      });
 
       const result = await auth.resetPassword(authDataSource, {
         password: '123456',
         confirmPassword: '111222333',
-        resetPasswordToken: data!.forgetPasswordToken,
+        resetPasswordToken: 'token',
       });
 
       expect(result).toStrictEqual({

--- a/tests/models/user.test.ts
+++ b/tests/models/user.test.ts
@@ -1,12 +1,10 @@
 import { createUserDataSource } from '@/data/user';
 import { database } from '@/infra/database';
 import { user } from '@/models/user';
-import { sleep } from '@/src/utils/sleep';
 import { sql } from '@/src/utils/syntax-highlighting';
 import { orchestrator } from '@/tests/orchestrator';
 
 beforeAll(async () => {
-  await sleep(3000);
   await orchestrator.resetDatabase();
 });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,5 +8,6 @@ export default defineConfig({
     typecheck: {
       enabled: true,
     },
+    fileParallelism: false,
   },
 });


### PR DESCRIPTION
## Context
- During previous implementations I noticed some errors in the terminal when trying to run the tests. Investigating further, I realized that the tests were running in parallel: `one doesn't wait for the other to finish execution`

I disabled the [`fileParallelism`](https://vitest.dev/config/#fileparallelism) option in `vitest.config.ts`.

I also deleted the `utils` function created to make the tests run with a workaround: `sleep`