### PR TITLE
[`forget-password`]: integrate `forgetPassword` functionalities with frontend

### DIFF
--- a/data/authentication.ts
+++ b/data/authentication.ts
@@ -19,6 +19,7 @@ export function createAuthenticationDataSource() {
 
   type Output = {
     id: string;
+    name: string;
     password: string;
   };
 
@@ -31,6 +32,7 @@ export function createAuthenticationDataSource() {
       text: sql`
         SELECT
           id,
+          name,
           password
         FROM
           users

--- a/models/email.ts
+++ b/models/email.ts
@@ -19,10 +19,28 @@ async function sendWelcomeMessage(input: EmailInput) {
     text: '',
   });
 
+  console.log('sendWelcomeMessage: ');
+  console.log({ data });
+  console.log({ error });
+}
+
+async function sendResetPasswordEmail(input: EmailInput) {
+  const { from, to, content } = input;
+
+  const { data, error } = await resend.emails.send({
+    from,
+    to,
+    subject: 'Redefinição de senha',
+    react: content,
+    text: '',
+  });
+
+  console.log('sendResetPasswordEmail: ');
   console.log({ data });
   console.log({ error });
 }
 
 export const emailService = Object.freeze({
   sendWelcomeMessage,
+  sendResetPasswordEmail,
 });

--- a/src/app/auth/forget-password/page.tsx
+++ b/src/app/auth/forget-password/page.tsx
@@ -1,0 +1,73 @@
+import { Button } from '@nextui-org/react';
+import { revalidatePath } from 'next/cache';
+import Link from 'next/link';
+
+import { createAuthenticationDataSource } from '@/data/authentication';
+import {
+  auth,
+  ForgetPasswordInput,
+  ForgetPasswordOutput,
+} from '@/models/authentication';
+import { Input } from '@/src/components/Input';
+import { SubmitButton } from '@/src/components/SubmitButton';
+import { form } from '@/src/utils/form';
+
+let responseMessage: ForgetPasswordOutput;
+let successMessage: {
+  email: string;
+};
+
+async function forgetPassword(formData: FormData) {
+  'use server';
+
+  const { email } = form.sanitizeData<ForgetPasswordInput>(formData);
+
+  const authDataSource = createAuthenticationDataSource();
+  responseMessage = await auth.forgetPassword(authDataSource, {
+    email,
+  });
+
+  if (responseMessage.data) {
+    successMessage = { email };
+  }
+
+  return revalidatePath('/auth/forget-password');
+}
+
+export default function Page() {
+  return (
+    <div className="space-y-4 px-5 md:w-96">
+      <h1 className="text-center text-2xl">
+        Esqueceu sua senha? Não se preocupe!
+      </h1>
+      <h2>
+        Digite seu email para enviarmos as instruções de recuperação de senha
+      </h2>
+
+      <form action={forgetPassword} className="flex flex-col space-y-3">
+        <Input
+          id="email"
+          label="Email*"
+          name="email"
+          required
+          error={auth.setInputError('email', responseMessage)}
+        />
+        <SubmitButton className="">Enviar</SubmitButton>
+      </form>
+
+      {successMessage && (
+        <>
+          <p className="mt-4 text-center text-sm text-green-400">
+            Instruções enviadas para <strong>{successMessage.email}</strong>
+          </p>
+
+          <Button className="rounded">
+            <Link className="hover:underline" href="/">
+              Voltar para página principal
+            </Link>
+          </Button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/auth/reset-password/page.tsx
+++ b/src/app/auth/reset-password/page.tsx
@@ -1,0 +1,89 @@
+import { revalidatePath } from 'next/cache';
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+
+import { createAuthenticationDataSource } from '@/data/authentication';
+import {
+  auth,
+  FailureAuthResponse,
+  ResetPasswordInput,
+} from '@/models/authentication';
+import { Input } from '@/src/components/Input';
+import { SubmitButton } from '@/src/components/SubmitButton';
+import { form } from '@/src/utils/form';
+import { Failure, Success } from '@/src/utils/operationResult';
+
+let responseMessage: Success<{}> | Failure<FailureAuthResponse>;
+
+async function resetPasswordAction(formData: FormData) {
+  'use server';
+
+  const data = form.sanitizeData<ResetPasswordInput>(formData);
+
+  const authDataSource = createAuthenticationDataSource();
+  responseMessage = await auth.resetPassword(authDataSource, data);
+
+  if (responseMessage.error) {
+    return revalidatePath('/auth/reset-password');
+  }
+
+  return redirect('/auth/signin');
+}
+
+type Props = {
+  searchParams: {
+    token: string;
+  };
+};
+
+export default function Page({ searchParams }: Props) {
+  const { token } = searchParams;
+
+  const result = auth.verifyResetPasswordToken({
+    resetPasswordToken: token,
+  });
+
+  if (!result) {
+    return (
+      <div>
+        <h1>
+          Token inválido ou expirado. Por favor, solicite uma nova recuperação
+          de senha.
+        </h1>
+
+        <br />
+
+        <Link href="/auth/forget-password" className="underline">
+          Solicitar nova recuperação de senha
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4 md:w-80">
+      <h1>Atualização de senha</h1>
+
+      <form action={resetPasswordAction} className="flex flex-col space-y-3">
+        <Input
+          required
+          id="password"
+          type="password"
+          name="password"
+          label="Digite uma nova senha"
+          error={auth.setInputError('password', responseMessage)}
+        />
+        <Input
+          required
+          id="confirmPassword"
+          type="password"
+          name="confirmPassword"
+          label="Confirmação de senha"
+          error={auth.setInputError('confirmPassword', responseMessage)}
+        />
+        <input type="hidden" value={token} name="resetPasswordToken" />
+        <SubmitButton>Enviar</SubmitButton>
+      </form>
+    </div>
+  );
+}

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -3,11 +3,7 @@ import Link from 'next/link';
 import { redirect } from 'next/navigation';
 
 import { createAuthenticationDataSource } from '@/data/authentication';
-import {
-  auth,
-  AvailableSignInFields,
-  SignInResponse,
-} from '@/models/authentication';
+import { auth, SignInResponse } from '@/models/authentication';
 import { Input } from '@/src/components/Input';
 import { SubmitButton } from '@/src/components/SubmitButton';
 import { constants } from '@/src/utils/constants';
@@ -47,22 +43,16 @@ type Props = {
 export default function Page({ searchParams }: Props) {
   const { userName } = searchParams;
 
-  function setInputError(inputName: AvailableSignInFields) {
-    if (!signInResponse?.error) return '';
-
-    const { fields, message } = signInResponse.error;
-    const inputHasError = fields.includes(inputName);
-
-    return inputHasError ? message : '';
-  }
-
   return (
     <div className="space-y-4 md:w-80">
       {userName && <p>Faça login para o usuário {userName}</p>}
       <h1 className="text-2xl">Entrar</h1>
-      <p>
+      <p className="text-gray-400">
         Não possui uma conta?{' '}
-        <Link href="/auth/signup" className="underline">
+        <Link
+          href="/auth/signup"
+          className="underline transition-colors hover:text-white"
+        >
           Cadastre-se
         </Link>
       </p>
@@ -73,7 +63,7 @@ export default function Page({ searchParams }: Props) {
           name="email"
           label="Email*"
           required
-          error={setInputError('email')}
+          error={auth.setInputError('email', signInResponse)}
         />
         <Input
           id="password"
@@ -81,10 +71,20 @@ export default function Page({ searchParams }: Props) {
           label="Senha*"
           type="password"
           required
-          error={setInputError('password')}
+          error={auth.setInputError('password', signInResponse)}
         />
         <SubmitButton>Entrar</SubmitButton>
       </form>
+
+      <p className="text-center text-sm text-gray-400">
+        Esqueceu sua senha?{' '}
+        <Link
+          href="/auth/forget-password"
+          className="underline transition-colors hover:text-white"
+        >
+          clique aqui
+        </Link>
+      </p>
     </div>
   );
 }

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -3,11 +3,7 @@ import Link from 'next/link';
 import { redirect } from 'next/navigation';
 
 import { createAuthenticationDataSource } from '@/data/authentication';
-import {
-  auth,
-  AvailableSignUpFields,
-  SignUpResponse,
-} from '@/models/authentication';
+import { auth, SignUpResponse } from '@/models/authentication';
 import { Input } from '@/src/components/Input';
 import { SubmitButton } from '@/src/components/SubmitButton';
 import { form } from '@/src/utils/form';
@@ -33,22 +29,15 @@ async function signUpAction(formData: FormData) {
 }
 
 export default function Page() {
-  function setInputError(inputName: AvailableSignUpFields) {
-    if (!signUpResponse?.error) return '';
-
-    const { message, fields } = signUpResponse.error;
-
-    const inputHasError = fields.includes(inputName);
-
-    return inputHasError ? message : '';
-  }
-
   return (
     <div className="space-y-4 md:w-80">
       <h1 className="text-2xl">Cadastre-se</h1>
-      <p>
+      <p className="text-gray-400">
         Já possui uma conta?{' '}
-        <Link href="/auth/signin" className="underline">
+        <Link
+          href="/auth/signin"
+          className="underline transition-colors hover:text-white"
+        >
           Fazer login
         </Link>
       </p>
@@ -60,14 +49,14 @@ export default function Page() {
           label="Nome*"
           name="name"
           autoComplete="off"
-          error={setInputError('name')}
+          error={auth.setInputError('name', signUpResponse)}
         />
         <Input
           required
           id="email"
           label="Email*"
           name="email"
-          error={setInputError('email')}
+          error={auth.setInputError('email', signUpResponse)}
         />
         <Input
           required
@@ -75,7 +64,7 @@ export default function Page() {
           label="Username*"
           name="userName"
           autoComplete="off"
-          error={setInputError('userName')}
+          error={auth.setInputError('userName', signUpResponse)}
         />
         <Input
           required
@@ -84,7 +73,7 @@ export default function Page() {
           type="password"
           name="password"
           autoComplete="off"
-          error={setInputError('password')}
+          error={auth.setInputError('password', signUpResponse)}
         />
         <Input
           required
@@ -93,7 +82,7 @@ export default function Page() {
           type="password"
           name="confirmPassword"
           autoComplete="off"
-          error={setInputError('confirmPassword')}
+          error={auth.setInputError('confirmPassword', signUpResponse)}
         />
         <SubmitButton>Cadastrar</SubmitButton>
       </form>

--- a/src/components/email-templates/ForgetPassword.tsx
+++ b/src/components/email-templates/ForgetPassword.tsx
@@ -1,0 +1,65 @@
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Html,
+  Preview,
+  Section,
+  Tailwind,
+  Text,
+} from '@react-email/components';
+
+interface ForgetPasswordEmailProps {
+  userFirstname?: string;
+  token?: string;
+}
+
+const baseUrl = 'http://localhost:3000';
+
+export const ForgetPasswordEmail = ({
+  userFirstname,
+  token,
+}: ForgetPasswordEmailProps) => {
+  const resetPasswordLink = `${baseUrl}/auth/reset-password?token=${token}`;
+
+  return (
+    <Html>
+      <Head />
+      <Preview>Onde Ir - esquecimento de senha</Preview>
+      <Tailwind>
+        <Body className="bg-[#f6f9fc] py-3">
+          <Container className="border border-[#f0f0f0] bg-[#ffffff] p-11">
+            <Section>
+              <Text className="font-light leading-6 text-[#404040]">
+                Olá, {userFirstname},
+              </Text>
+              <Text className="font-light leading-6 text-[#404040]">
+                Recebemos uma solicitação para redefinir a senha da sua conta.
+                Essa solicitação irá durar 5 minutos. Clique no botão abaixo
+                para criar uma nova senha.
+              </Text>
+              <Button
+                className="block w-52 rounded bg-[#007ee6] px-2 py-3 text-center text-[#fff]"
+                href={resetPasswordLink}
+              >
+                Mudar senha
+              </Button>
+              <Text className="font-light leading-6 text-[#404040]">
+                Se você não solicitou uma redefinição de senha, ignore este
+                e-mail.
+              </Text>
+              <Text className="font-light leading-6 text-[#404040]">
+                Para manter sua conta segura, não compartilhe este e-mail com
+                ninguém.
+              </Text>
+              <Text className="font-light leading-6 text-[#404040]">
+                Obrigado por usar nosso serviço, esperamos vê-lo em breve!
+              </Text>
+            </Section>
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  );
+};


### PR DESCRIPTION
- closes #63

## Done
- refactored `findUserByEmail` method to retrieve user `name` too
- create function and template to send email informing `forgetPassword` action
- refactored a helper function `setInputError`, turning it a globally method (in the authentication context).
- created `forget-password` page
- created `reset-password` page

**OBS**: For now, I'm just sending email to my personal account as I haven't created a custom email domain yet.