### PR TITLE
[`models/authentication`]: stop exposing `resetPasswordTokenId` to the client

### DIFF
--- a/src/app/auth/reset-password/page.tsx
+++ b/src/app/auth/reset-password/page.tsx
@@ -32,16 +32,21 @@ async function resetPasswordAction(formData: FormData) {
 
 type Props = {
   searchParams: {
-    token: string;
+    tokenId: string;
   };
 };
 
 export default function Page({ searchParams }: Props) {
-  const { token } = searchParams;
+  const { tokenId } = searchParams;
 
-  const result = auth.verifyResetPasswordToken({
-    resetPasswordToken: token,
-  });
+  const result = true;
+
+  const hasAuthenticationErrorMessage =
+    !responseMessage?.data && responseMessage?.error?.fields.length === 0;
+
+  const errorMessage =
+    hasAuthenticationErrorMessage &&
+    responseMessage.error?.message.replace('resetPasswordTokenId', 'tokenId');
 
   if (!result) {
     return (
@@ -64,7 +69,11 @@ export default function Page({ searchParams }: Props) {
     <div className="space-y-4 md:w-80">
       <h1>Atualização de senha</h1>
 
-      <form action={resetPasswordAction} className="flex flex-col space-y-3">
+      <form
+        key={Date.toString()}
+        action={resetPasswordAction}
+        className="flex flex-col space-y-3"
+      >
         <Input
           required
           id="password"
@@ -81,9 +90,13 @@ export default function Page({ searchParams }: Props) {
           label="Confirmação de senha"
           error={auth.setInputError('confirmPassword', responseMessage)}
         />
-        <input type="hidden" value={token} name="resetPasswordToken" />
+        <input type="hidden" value={tokenId} name="resetPasswordTokenId" />
         <SubmitButton>Enviar</SubmitButton>
       </form>
+
+      {errorMessage && (
+        <p className="text-center text-red-400">{errorMessage}</p>
+      )}
     </div>
   );
 }

--- a/src/components/email-templates/ForgetPassword.tsx
+++ b/src/components/email-templates/ForgetPassword.tsx
@@ -12,16 +12,16 @@ import {
 
 interface ForgetPasswordEmailProps {
   userFirstname?: string;
-  token?: string;
+  resetPasswordTokenId?: string;
 }
 
 const baseUrl = 'http://localhost:3000';
 
 export const ForgetPasswordEmail = ({
   userFirstname,
-  token,
+  resetPasswordTokenId,
 }: ForgetPasswordEmailProps) => {
-  const resetPasswordLink = `${baseUrl}/auth/reset-password?token=${token}`;
+  const resetPasswordLink = `${baseUrl}/auth/reset-password?tokenId=${resetPasswordTokenId}`;
 
   return (
     <Html>


### PR DESCRIPTION
- This PR closes #65.

Now, to `reset-password` we have to provide a `resetPasswordTokenId` instead of  `resetPasswordToken`.

With that change, we stop exposing the token and handle with it internal in `resetPassword` method, fetching the token by `resetPasswordTokenId` and making validations