### PR TITLE
[`models/validator`]: create global schema `validator` function

### DIFF
--- a/models/validator.ts
+++ b/models/validator.ts
@@ -1,0 +1,95 @@
+import { z } from 'zod';
+
+import { operationResult } from '@/src/utils/operationResult';
+
+export function validator<T extends Partial<ValidationSchema>>(
+  payload: T,
+  keys: Record<keyof T, ValidationKeysOptions>,
+) {
+  if (Object.keys(payload).length === 0) {
+    return operationResult.failure({
+      message: 'input must not be empty.',
+    });
+  }
+
+  let message = '';
+  let output = {} as T;
+
+  for (const [key, value] of Object.entries(payload)) {
+    const validationKey = key as ValidationSchemaKeys;
+
+    const keySchema = schema.pick({ [validationKey]: true as never });
+
+    const validationOption = keys[validationKey];
+
+    if (validationOption === 'optional' && value === undefined) continue;
+
+    if (validationOption === 'optional') {
+      keySchema.optional();
+    }
+
+    const { success, error, data } = keySchema.safeParse({
+      [validationKey]: value,
+    });
+
+    if (!success) {
+      message = error.errors[0].message;
+      break;
+    }
+
+    output[validationKey] = data[validationKey];
+  }
+
+  if (message) {
+    return operationResult.failure({
+      message,
+    });
+  }
+
+  return operationResult.success(output);
+}
+
+type ValidationSchema = z.infer<typeof schema>;
+type ValidationKeysOptions = 'required' | 'optional';
+type ValidationSchemaKeys = keyof ValidationSchema;
+
+const schema = z.object({
+  name: z
+    .string({
+      required_error: '"name" é obrigatório.',
+      invalid_type_error: '"name" precisa ser uma string.',
+    })
+    .min(3, {
+      message: '"name" precisa ter no mínimo 3 caracteres.',
+    }),
+  email: z
+    .string({
+      required_error: '"email" é obrigatório.',
+      invalid_type_error: '"email" precisa ser uma string.',
+    })
+    .email({
+      message: '"email" precisa ser um email válido.',
+    }),
+  userName: z
+    .string({
+      required_error: '"userName" é obrigatório.',
+      invalid_type_error: '"userName" precisa ser uma string.',
+    })
+    .refine((s) => !s.includes(' '), '"userName" não pode ter espaços.'),
+  password: z
+    .string({
+      required_error: '"password" é obrigatório.',
+      invalid_type_error: '"password" precisa ser uma string.',
+    })
+    .min(6, {
+      message: '"password" precisa ter no mínimo 6 caracteres.',
+    }),
+  confirmPassword: z
+    .string({
+      required_error: '"confirmPassword" é obrigatório.',
+      invalid_type_error: '"confirmPassword" precisa ser uma string.',
+    })
+    .min(6, {
+      message: '"confirmPassword" precisa ter no mínimo 6 caracteres.',
+    }),
+});

--- a/tests/models/validator.test.ts
+++ b/tests/models/validator.test.ts
@@ -1,0 +1,632 @@
+import { validator } from '@/models/validator';
+
+describe('> models/validator', () => {
+  test('Providing an empty object', () => {
+    const result = validator({}, {});
+
+    expect(result).toStrictEqual({
+      data: null,
+      error: {
+        message: 'input must not be empty.',
+      },
+    });
+  });
+
+  test('Providing a undefined value to optional parameter', () => {
+    const result = validator(
+      {
+        name: undefined,
+      },
+      {
+        name: 'optional',
+      },
+    );
+
+    expect(result).toStrictEqual({
+      data: {},
+      error: null,
+    });
+  });
+
+  test('Providing a null value to optional parameter', () => {
+    const result = validator(
+      {
+        name: null as any,
+      },
+      {
+        name: 'optional',
+      },
+    );
+
+    expect(result).toStrictEqual({
+      data: null,
+      error: {
+        message: '"name" precisa ser uma string.',
+      },
+    });
+  });
+
+  test('Providing a null value to required parameter', () => {
+    const result = validator(
+      {
+        name: null as any,
+      },
+      {
+        name: 'required',
+      },
+    );
+
+    expect(result).toStrictEqual({
+      data: null,
+      error: {
+        message: '"name" precisa ser uma string.',
+      },
+    });
+  });
+
+  test('Providing a undefined value to required parameter', () => {
+    const result = validator(
+      {
+        name: undefined,
+      },
+      {
+        name: 'required',
+      },
+    );
+
+    expect(result).toStrictEqual({
+      data: null,
+      error: {
+        message: '"name" é obrigatório.',
+      },
+    });
+  });
+
+  describe('Testing "name"', () => {
+    test('Providing a valid value to optional parameter', () => {
+      const result = validator(
+        {
+          name: 'Gabriel',
+        },
+        {
+          name: 'optional',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        error: null,
+        data: {
+          name: 'Gabriel',
+        },
+      });
+    });
+
+    test('Providing a invalid type to optional parameter', () => {
+      const result = validator(
+        {
+          name: 123 as any,
+        },
+        {
+          name: 'optional',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: null,
+        error: {
+          message: '"name" precisa ser uma string.',
+        },
+      });
+    });
+
+    test('Providing name with less than 3 characters and optional parameter', () => {
+      const result = validator(
+        {
+          name: 'ga',
+        },
+        {
+          name: 'optional',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: null,
+        error: {
+          message: '"name" precisa ter no mínimo 3 caracteres.',
+        },
+      });
+    });
+
+    test('Providing a invalid type to required parameter', () => {
+      const result = validator(
+        {
+          name: 123 as any,
+        },
+        {
+          name: 'required',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: null,
+        error: {
+          message: '"name" precisa ser uma string.',
+        },
+      });
+    });
+
+    test('Providing name with less than 3 characters and required parameter', () => {
+      const result = validator(
+        {
+          name: 'ga',
+        },
+        {
+          name: 'required',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: null,
+        error: {
+          message: '"name" precisa ter no mínimo 3 caracteres.',
+        },
+      });
+    });
+  });
+
+  describe('Testing "email"', () => {
+    test('Providing valid value to optional parameter', () => {
+      const email = 'teste@email.com';
+
+      const result = validator(
+        {
+          email: email,
+        },
+        {
+          email: 'optional',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: {
+          email: email,
+        },
+        error: null,
+      });
+    });
+
+    test('Providing a invalid type to optional parameter', () => {
+      const result = validator(
+        {
+          email: 123 as any,
+        },
+        {
+          email: 'optional',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: null,
+        error: {
+          message: '"email" precisa ser uma string.',
+        },
+      });
+    });
+
+    test('Providing a invalid email to optional parameter', () => {
+      const result = validator(
+        {
+          email: 'testeemail.com',
+        },
+        {
+          email: 'optional',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: null,
+        error: {
+          message: '"email" precisa ser um email válido.',
+        },
+      });
+    });
+
+    test('Providing a invalid type to required parameter', () => {
+      const result = validator(
+        {
+          email: 123 as any,
+        },
+        {
+          email: 'required',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: null,
+        error: {
+          message: '"email" precisa ser uma string.',
+        },
+      });
+    });
+
+    test('Providing a invalid email to required parameter', () => {
+      const result = validator(
+        {
+          email: 'testeemail.com',
+        },
+        {
+          email: 'required',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: null,
+        error: {
+          message: '"email" precisa ser um email válido.',
+        },
+      });
+    });
+
+    test('Providing valid value to required parameter', () => {
+      const email = 'teste@email.com';
+
+      const result = validator(
+        {
+          email: email,
+        },
+        {
+          email: 'required',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: {
+          email: email,
+        },
+        error: null,
+      });
+    });
+  });
+
+  describe('Testing "userName"', () => {
+    test('Providing valid value to optional parameter', () => {
+      const userName = 'testeusername';
+
+      const result = validator(
+        {
+          userName,
+        },
+        {
+          userName: 'optional',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: {
+          userName,
+        },
+        error: null,
+      });
+    });
+
+    test('Providing a invalid type to optional parameter', () => {
+      const result = validator(
+        {
+          userName: 123 as any,
+        },
+        {
+          userName: 'optional',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: null,
+        error: {
+          message: '"userName" precisa ser uma string.',
+        },
+      });
+    });
+
+    test('Providing a invalid userName (with spaces) to optional parameter', () => {
+      const result = validator(
+        {
+          userName: 'user name',
+        },
+        {
+          userName: 'optional',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: null,
+        error: {
+          message: '"userName" não pode ter espaços.',
+        },
+      });
+    });
+
+    test('Providing a invalid type to required parameter', () => {
+      const result = validator(
+        {
+          userName: 123 as any,
+        },
+        {
+          userName: 'required',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: null,
+        error: {
+          message: '"userName" precisa ser uma string.',
+        },
+      });
+    });
+
+    test('Providing a invalid userName (with spaces) to required parameter', () => {
+      const result = validator(
+        {
+          userName: 'user name',
+        },
+        {
+          userName: 'required',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: null,
+        error: {
+          message: '"userName" não pode ter espaços.',
+        },
+      });
+    });
+
+    test('Providing valid value to required parameter', () => {
+      const userName = 'testeusername';
+
+      const result = validator(
+        {
+          userName,
+        },
+        {
+          userName: 'required',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: {
+          userName,
+        },
+        error: null,
+      });
+    });
+  });
+
+  describe('Testing "password"', () => {
+    test('Providing valid value to optional parameter', () => {
+      const password = 'password';
+
+      const result = validator(
+        {
+          password,
+        },
+        {
+          password: 'optional',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: {
+          password,
+        },
+        error: null,
+      });
+    });
+
+    test('Providing a invalid type to optional parameter', () => {
+      const result = validator(
+        {
+          password: 123 as any,
+        },
+        {
+          password: 'optional',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: null,
+        error: {
+          message: '"password" precisa ser uma string.',
+        },
+      });
+    });
+
+    test('Providing a "password" with less than 6 characters to optional parameter', () => {
+      const result = validator(
+        {
+          password: 'pass',
+        },
+        {
+          password: 'optional',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: null,
+        error: {
+          message: '"password" precisa ter no mínimo 6 caracteres.',
+        },
+      });
+    });
+
+    test('Providing valid value to optional parameter', () => {
+      const password = 'password';
+
+      const result = validator(
+        {
+          password,
+        },
+        {
+          password: 'optional',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: {
+          password,
+        },
+        error: null,
+      });
+    });
+
+    test('Providing a invalid type to optional parameter', () => {
+      const result = validator(
+        {
+          password: 123 as any,
+        },
+        {
+          password: 'optional',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: null,
+        error: {
+          message: '"password" precisa ser uma string.',
+        },
+      });
+    });
+
+    test('Providing a "password" with less than 6 characters to optional parameter', () => {
+      const result = validator(
+        {
+          password: 'pass',
+        },
+        {
+          password: 'optional',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: null,
+        error: {
+          message: '"password" precisa ter no mínimo 6 caracteres.',
+        },
+      });
+    });
+  });
+
+  describe('Testing "confirmPassword"', () => {
+    test('Providing valid value to optional parameter', () => {
+      const confirmPassword = 'confirmPassword';
+
+      const result = validator(
+        {
+          confirmPassword,
+        },
+        {
+          confirmPassword: 'optional',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: {
+          confirmPassword,
+        },
+        error: null,
+      });
+    });
+
+    test('Providing a invalid type to optional parameter', () => {
+      const result = validator(
+        {
+          confirmPassword: 123 as any,
+        },
+        {
+          confirmPassword: 'optional',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: null,
+        error: {
+          message: '"confirmPassword" precisa ser uma string.',
+        },
+      });
+    });
+
+    test('Providing a "confirmPassword" with less than 6 characters to optional parameter', () => {
+      const result = validator(
+        {
+          confirmPassword: 'pass',
+        },
+        {
+          confirmPassword: 'optional',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: null,
+        error: {
+          message: '"confirmPassword" precisa ter no mínimo 6 caracteres.',
+        },
+      });
+    });
+
+    test('Providing valid value to optional parameter', () => {
+      const confirmPassword = 'confirmPassword';
+
+      const result = validator(
+        {
+          confirmPassword,
+        },
+        {
+          confirmPassword: 'optional',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: {
+          confirmPassword,
+        },
+        error: null,
+      });
+    });
+
+    test('Providing a invalid type to optional parameter', () => {
+      const result = validator(
+        {
+          confirmPassword: 123 as any,
+        },
+        {
+          confirmPassword: 'optional',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: null,
+        error: {
+          message: '"confirmPassword" precisa ser uma string.',
+        },
+      });
+    });
+
+    test('Providing a "confirmPassword" with less than 6 characters to optional parameter', () => {
+      const result = validator(
+        {
+          confirmPassword: 'pass',
+        },
+        {
+          confirmPassword: 'optional',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: null,
+        error: {
+          message: '"confirmPassword" precisa ter no mínimo 6 caracteres.',
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
- This PR closes #60

## Now we have a global method to validate all the application inputs (using zod behind the hood).

## How to use:
```tsx
const { data, error } = validator({
  name: 'teste',
  email: 'teste@email.com'
}, {
  name: 'optional',
  email: 'required'
})
```