### PR TITLE
[`validator`]: Use validator in some `models/authenticaton` methods

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,14 +38,6 @@
           }
         ]
       }
-    ],
-    "sort-imports": [
-      "error",
-      {
-        "allowSeparatedGroups": true,
-        "ignoreCase": true,
-        "ignoreDeclarationSort": true
-      }
     ]
   }
 }

--- a/data/authentication.ts
+++ b/data/authentication.ts
@@ -1,6 +1,6 @@
 import { database } from '@/infra/database';
+import { SignUpProps } from '@/models/authentication';
 import { sql } from '@/src/utils/syntax-highlighting';
-import { SignUpProps } from '@/types';
 
 export type AuthenticationDataSource = ReturnType<
   typeof createAuthenticationDataSource

--- a/models/validator.ts
+++ b/models/validator.ts
@@ -66,6 +66,7 @@ const schema = z.object({
       required_error: '"name" é obrigatório.',
       invalid_type_error: '"name" precisa ser uma string.',
     })
+    .trim()
     .min(3, {
       message: '"name" precisa ter no mínimo 3 caracteres.',
     }),

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -3,12 +3,11 @@ import Link from 'next/link';
 import { redirect } from 'next/navigation';
 
 import { createAuthenticationDataSource } from '@/data/authentication';
-import { auth, SignInResponse } from '@/models/authentication';
+import { auth, SignInProps, SignInResponse } from '@/models/authentication';
 import { Input } from '@/src/components/Input';
 import { SubmitButton } from '@/src/components/SubmitButton';
 import { constants } from '@/src/utils/constants';
 import { form } from '@/src/utils/form';
-import { SignInProps } from '@/types';
 
 let signInResponse: SignInResponse;
 

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -3,11 +3,10 @@ import Link from 'next/link';
 import { redirect } from 'next/navigation';
 
 import { createAuthenticationDataSource } from '@/data/authentication';
-import { auth, SignUpResponse } from '@/models/authentication';
+import { auth, SignUpProps, SignUpResponse } from '@/models/authentication';
 import { Input } from '@/src/components/Input';
 import { SubmitButton } from '@/src/components/SubmitButton';
 import { form } from '@/src/utils/form';
-import { SignUpProps } from '@/types';
 
 let signUpResponse: SignUpResponse;
 

--- a/tests/models/auth.test.ts
+++ b/tests/models/auth.test.ts
@@ -2,9 +2,8 @@ import { randomUUID } from 'node:crypto';
 
 import { createAuthenticationDataSource } from '@/data/authentication';
 import { database } from '@/infra/database';
-import { auth } from '@/models/authentication';
+import { SignInProps, SignUpProps, auth } from '@/models/authentication';
 import { orchestrator } from '@/tests/orchestrator';
-import { SignInProps, SignUpProps } from '@/types';
 
 beforeAll(async () => {
   await orchestrator.resetDatabase();
@@ -77,7 +76,7 @@ describe('> models/authentication', () => {
       expect(result).toStrictEqual({
         data: null,
         error: {
-          message: 'O e-mail precisa ser válido',
+          message: '"email" precisa ser um email válido.',
           fields: ['email'],
         },
       });
@@ -99,7 +98,7 @@ describe('> models/authentication', () => {
       expect(result).toStrictEqual({
         data: null,
         error: {
-          message: 'O nome precisa ter no mínimo 3 caracteres',
+          message: '"name" precisa ter no mínimo 3 caracteres.',
           fields: ['name'],
         },
       });
@@ -120,7 +119,7 @@ describe('> models/authentication', () => {
       expect(result).toStrictEqual({
         data: null,
         error: {
-          message: 'O nome de usuário não pode ter espaços',
+          message: '"userName" não pode ter espaços.',
           fields: ['userName'],
         },
       });
@@ -141,7 +140,7 @@ describe('> models/authentication', () => {
       expect(result).toStrictEqual({
         data: null,
         error: {
-          message: 'A senha precisa ter no mínimo 6 caracteres',
+          message: '"password" precisa ter no mínimo 6 caracteres.',
           fields: ['password'],
         },
       });
@@ -154,8 +153,8 @@ describe('> models/authentication', () => {
       expect(result).toStrictEqual({
         data: null,
         error: {
-          message: 'O nome é obrigatório',
-          fields: ['name'],
+          message: '"email" é obrigatório.',
+          fields: ['email'],
         },
       });
     });
@@ -175,7 +174,7 @@ describe('> models/authentication', () => {
       expect(result).toStrictEqual({
         data: null,
         error: {
-          message: 'O e-mail é obrigatório',
+          message: '"email" é obrigatório.',
           fields: ['email'],
         },
       });
@@ -235,7 +234,7 @@ describe('> models/authentication', () => {
       expect(result).toStrictEqual({
         data: null,
         error: {
-          message: 'O e-mail é obrigatório',
+          message: '"email" é obrigatório.',
           fields: ['email'],
         },
       });
@@ -251,7 +250,7 @@ describe('> models/authentication', () => {
       expect(result).toStrictEqual({
         data: null,
         error: {
-          message: 'O e-mail é obrigatório',
+          message: '"email" é obrigatório.',
           fields: ['email'],
         },
       });
@@ -267,7 +266,7 @@ describe('> models/authentication', () => {
       expect(result).toStrictEqual({
         data: null,
         error: {
-          message: 'A senha é obrigatória',
+          message: '"password" é obrigatório.',
           fields: ['password'],
         },
       });
@@ -334,7 +333,7 @@ describe('> models/authentication', () => {
 
       expect(result).toStrictEqual({
         error: {
-          message: 'O e-mail precisa ser válido',
+          message: '"email" precisa ser um email válido.',
           fields: ['email'],
         },
         data: null,
@@ -352,7 +351,7 @@ describe('> models/authentication', () => {
       expect(result).toStrictEqual({
         data: null,
         error: {
-          message: 'O e-mail precisa ser válido',
+          message: '"email" precisa ser um email válido.',
           fields: ['email'],
         },
       });
@@ -365,7 +364,7 @@ describe('> models/authentication', () => {
       expect(result).toStrictEqual({
         data: null,
         error: {
-          message: 'O e-mail é obrigatório',
+          message: '"email" é obrigatório.',
           fields: ['email'],
         },
       });
@@ -413,8 +412,8 @@ describe('> models/authentication', () => {
       expect(result).toStrictEqual({
         data: null,
         error: {
-          message: 'A propriedade "resetPasswordTokenId" é obrigatória.',
-          fields: [],
+          message: '"resetPasswordTokenId" é obrigatório.',
+          fields: ['resetPasswordTokenId'],
         },
       });
     });
@@ -430,8 +429,8 @@ describe('> models/authentication', () => {
       expect(result).toStrictEqual({
         data: null,
         error: {
-          message: 'O "resetPasswordTokenId" precisa ser um UUID.',
-          fields: [],
+          message: '"resetPasswordTokenId" precisa ser um UUID válido.',
+          fields: ['resetPasswordTokenId'],
         },
       });
     });
@@ -449,8 +448,8 @@ describe('> models/authentication', () => {
       expect(result).toStrictEqual({
         data: null,
         error: {
-          message: 'A senha é obrigatória',
-          fields: ['password', 'confirmPassword'],
+          message: '"password" é obrigatório.',
+          fields: ['password'],
         },
       });
     });
@@ -468,8 +467,8 @@ describe('> models/authentication', () => {
       expect(result).toStrictEqual({
         data: null,
         error: {
-          message: 'A confirmação de senha é obrigatória',
-          fields: ['password', 'confirmPassword'],
+          message: '"confirmPassword" é obrigatório.',
+          fields: ['confirmPassword'],
         },
       });
     });
@@ -485,8 +484,8 @@ describe('> models/authentication', () => {
       expect(result).toStrictEqual({
         data: null,
         error: {
-          message: 'A senha precisa ter no mínimo 6 caracteres',
-          fields: ['password', 'confirmPassword'],
+          message: '"password" precisa ter no mínimo 6 caracteres.',
+          fields: ['password'],
         },
       });
     });
@@ -503,7 +502,7 @@ describe('> models/authentication', () => {
       expect(result).toStrictEqual({
         data: null,
         error: {
-          message: 'As senhas precisam ser iguais',
+          message: 'As senhas precisam ser iguais.',
           fields: ['password', 'confirmPassword'],
         },
       });

--- a/tests/models/validator.test.ts
+++ b/tests/models/validator.test.ts
@@ -180,6 +180,26 @@ describe('> models/validator', () => {
         },
       });
     });
+
+    test('Providing a untrimmed name', () => {
+      const untrimmedName = '  Gabriel  ';
+
+      const result = validator(
+        {
+          name: untrimmedName,
+        },
+        {
+          name: 'required',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: {
+          name: 'Gabriel',
+        },
+        error: null,
+      });
+    });
   });
 
   describe('Testing "email"', () => {
@@ -595,7 +615,7 @@ describe('> models/validator', () => {
       });
     });
 
-    test('Providing valid value to optional parameter', () => {
+    test('Providing valid value to required parameter', () => {
       const confirmPassword = 'confirmPassword';
 
       const result = validator(
@@ -603,7 +623,7 @@ describe('> models/validator', () => {
           confirmPassword,
         },
         {
-          confirmPassword: 'optional',
+          confirmPassword: 'required',
         },
       );
 
@@ -615,13 +635,13 @@ describe('> models/validator', () => {
       });
     });
 
-    test('Providing a invalid type to optional parameter', () => {
+    test('Providing a invalid type to required parameter', () => {
       const result = validator(
         {
           confirmPassword: 123 as any,
         },
         {
-          confirmPassword: 'optional',
+          confirmPassword: 'required',
         },
       );
 
@@ -634,13 +654,13 @@ describe('> models/validator', () => {
       });
     });
 
-    test('Providing a "confirmPassword" with less than 6 characters to optional parameter', () => {
+    test('Providing a "confirmPassword" with less than 6 characters to required parameter', () => {
       const result = validator(
         {
           confirmPassword: 'pass',
         },
         {
-          confirmPassword: 'optional',
+          confirmPassword: 'required',
         },
       );
 
@@ -649,6 +669,124 @@ describe('> models/validator', () => {
         error: {
           message: '"confirmPassword" precisa ter no mínimo 6 caracteres.',
           fields: ['confirmPassword'],
+        },
+      });
+    });
+  });
+
+  describe('Testing "resetPasswordTokenId"', () => {
+    test('Providing valid value to optional parameter', () => {
+      const resetPasswordTokenId = '00000000-0000-0000-0000-000000000000';
+
+      const result = validator(
+        {
+          resetPasswordTokenId,
+        },
+        {
+          resetPasswordTokenId: 'optional',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: {
+          resetPasswordTokenId,
+        },
+        error: null,
+      });
+    });
+
+    test('Providing a invalid type to optional parameter (number)', () => {
+      const result = validator(
+        {
+          resetPasswordTokenId: 123 as any,
+        },
+        {
+          resetPasswordTokenId: 'optional',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: null,
+        error: {
+          message: '"resetPasswordTokenId" precisa ser uma string.',
+          fields: ['resetPasswordTokenId'],
+        },
+      });
+    });
+
+    test('Providing a invalid type to optional parameter (not UUID)', () => {
+      const result = validator(
+        {
+          resetPasswordTokenId: '123' as any,
+        },
+        {
+          resetPasswordTokenId: 'optional',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: null,
+        error: {
+          message: '"resetPasswordTokenId" precisa ser um UUID válido.',
+          fields: ['resetPasswordTokenId'],
+        },
+      });
+    });
+
+    test('Providing valid value to required parameter', () => {
+      const resetPasswordTokenId = '00000000-0000-0000-0000-000000000000';
+
+      const result = validator(
+        {
+          resetPasswordTokenId,
+        },
+        {
+          resetPasswordTokenId: 'required',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: {
+          resetPasswordTokenId,
+        },
+        error: null,
+      });
+    });
+
+    test('Providing a invalid type to required parameter (number)', () => {
+      const result = validator(
+        {
+          resetPasswordTokenId: 123 as any,
+        },
+        {
+          resetPasswordTokenId: 'required',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: null,
+        error: {
+          message: '"resetPasswordTokenId" precisa ser uma string.',
+          fields: ['resetPasswordTokenId'],
+        },
+      });
+    });
+
+    test('Providing a invalid type to required parameter (not UUID)', () => {
+      const result = validator(
+        {
+          resetPasswordTokenId: '123' as any,
+        },
+        {
+          resetPasswordTokenId: 'required',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: null,
+        error: {
+          message: '"resetPasswordTokenId" precisa ser um UUID válido.',
+          fields: ['resetPasswordTokenId'],
         },
       });
     });

--- a/tests/models/validator.test.ts
+++ b/tests/models/validator.test.ts
@@ -7,7 +7,8 @@ describe('> models/validator', () => {
     expect(result).toStrictEqual({
       data: null,
       error: {
-        message: 'input must not be empty.',
+        message: 'O input não pode ser vazio.',
+        fields: [],
       },
     });
   });
@@ -42,6 +43,7 @@ describe('> models/validator', () => {
       data: null,
       error: {
         message: '"name" precisa ser uma string.',
+        fields: ['name'],
       },
     });
   });
@@ -60,6 +62,7 @@ describe('> models/validator', () => {
       data: null,
       error: {
         message: '"name" precisa ser uma string.',
+        fields: ['name'],
       },
     });
   });
@@ -78,6 +81,7 @@ describe('> models/validator', () => {
       data: null,
       error: {
         message: '"name" é obrigatório.',
+        fields: ['name'],
       },
     });
   });
@@ -115,6 +119,7 @@ describe('> models/validator', () => {
         data: null,
         error: {
           message: '"name" precisa ser uma string.',
+          fields: ['name'],
         },
       });
     });
@@ -133,6 +138,7 @@ describe('> models/validator', () => {
         data: null,
         error: {
           message: '"name" precisa ter no mínimo 3 caracteres.',
+          fields: ['name'],
         },
       });
     });
@@ -151,6 +157,7 @@ describe('> models/validator', () => {
         data: null,
         error: {
           message: '"name" precisa ser uma string.',
+          fields: ['name'],
         },
       });
     });
@@ -169,6 +176,7 @@ describe('> models/validator', () => {
         data: null,
         error: {
           message: '"name" precisa ter no mínimo 3 caracteres.',
+          fields: ['name'],
         },
       });
     });
@@ -209,6 +217,7 @@ describe('> models/validator', () => {
         data: null,
         error: {
           message: '"email" precisa ser uma string.',
+          fields: ['email'],
         },
       });
     });
@@ -227,6 +236,7 @@ describe('> models/validator', () => {
         data: null,
         error: {
           message: '"email" precisa ser um email válido.',
+          fields: ['email'],
         },
       });
     });
@@ -245,6 +255,7 @@ describe('> models/validator', () => {
         data: null,
         error: {
           message: '"email" precisa ser uma string.',
+          fields: ['email'],
         },
       });
     });
@@ -263,6 +274,7 @@ describe('> models/validator', () => {
         data: null,
         error: {
           message: '"email" precisa ser um email válido.',
+          fields: ['email'],
         },
       });
     });
@@ -323,6 +335,7 @@ describe('> models/validator', () => {
         data: null,
         error: {
           message: '"userName" precisa ser uma string.',
+          fields: ['userName'],
         },
       });
     });
@@ -341,6 +354,7 @@ describe('> models/validator', () => {
         data: null,
         error: {
           message: '"userName" não pode ter espaços.',
+          fields: ['userName'],
         },
       });
     });
@@ -359,6 +373,7 @@ describe('> models/validator', () => {
         data: null,
         error: {
           message: '"userName" precisa ser uma string.',
+          fields: ['userName'],
         },
       });
     });
@@ -377,6 +392,7 @@ describe('> models/validator', () => {
         data: null,
         error: {
           message: '"userName" não pode ter espaços.',
+          fields: ['userName'],
         },
       });
     });
@@ -437,6 +453,7 @@ describe('> models/validator', () => {
         data: null,
         error: {
           message: '"password" precisa ser uma string.',
+          fields: ['password'],
         },
       });
     });
@@ -455,6 +472,7 @@ describe('> models/validator', () => {
         data: null,
         error: {
           message: '"password" precisa ter no mínimo 6 caracteres.',
+          fields: ['password'],
         },
       });
     });
@@ -493,6 +511,7 @@ describe('> models/validator', () => {
         data: null,
         error: {
           message: '"password" precisa ser uma string.',
+          fields: ['password'],
         },
       });
     });
@@ -511,6 +530,7 @@ describe('> models/validator', () => {
         data: null,
         error: {
           message: '"password" precisa ter no mínimo 6 caracteres.',
+          fields: ['password'],
         },
       });
     });
@@ -551,6 +571,7 @@ describe('> models/validator', () => {
         data: null,
         error: {
           message: '"confirmPassword" precisa ser uma string.',
+          fields: ['confirmPassword'],
         },
       });
     });
@@ -569,6 +590,7 @@ describe('> models/validator', () => {
         data: null,
         error: {
           message: '"confirmPassword" precisa ter no mínimo 6 caracteres.',
+          fields: ['confirmPassword'],
         },
       });
     });
@@ -607,6 +629,7 @@ describe('> models/validator', () => {
         data: null,
         error: {
           message: '"confirmPassword" precisa ser uma string.',
+          fields: ['confirmPassword'],
         },
       });
     });
@@ -625,6 +648,7 @@ describe('> models/validator', () => {
         data: null,
         error: {
           message: '"confirmPassword" precisa ter no mínimo 6 caracteres.',
+          fields: ['confirmPassword'],
         },
       });
     });

--- a/types/SignIn.ts
+++ b/types/SignIn.ts
@@ -1,4 +1,0 @@
-export type SignInProps = {
-  email: string;
-  password: string;
-};

--- a/types/SignUp.ts
+++ b/types/SignUp.ts
@@ -1,7 +1,0 @@
-export type SignUpProps = {
-  email: string;
-  name: string;
-  userName: string;
-  password: string;
-  confirmPassword: string;
-};

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,5 +1,1 @@
-export * from './SignIn';
-
-export * from './SignUp';
-
 export * from './User';


### PR DESCRIPTION
## Done:
- Adjustments in `models/validator` to return always `fields` array
- Use `validator` to validate `signUp` input
- Use `validator` to validate `signIn` input
- Use `validator` to validate `forgetPassword` input
- Use `validator` to validate `resetPassword` input

## To be done:
 - Use `validator` to validate `changePassword` input