### PR TITLE
[`models/user`]: moves `findById` schema to validator

### DIFF
--- a/models/validator.ts
+++ b/models/validator.ts
@@ -46,7 +46,7 @@ export function validator<T extends Partial<ValidationSchema>>(
       break;
     }
 
-    output[validationKey] = data[validationKey];
+    output = { ...output, ...data };
   }
 
   if (responseMessage?.message) {
@@ -136,4 +136,30 @@ const schema = z.object({
     .min(6, {
       message: '"confirmNewPassword" precisa ter no mínimo 6 caracteres.',
     }),
+  selectUserFields: z.array(
+    z
+      .string({
+        invalid_type_error:
+          '"selectUserFields" precisa ser um array de strings.',
+        required_error: '"selectUserFields" é obrigatório.',
+      })
+      .refine(
+        (field) =>
+          [
+            'id',
+            'email',
+            'name',
+            'password',
+            'userName',
+            'userRole',
+            'createdAt',
+            'updatedAt',
+          ].includes(field),
+        '"selectUserFields" precisa conter apenas propriedades válidas.',
+      ),
+    {
+      invalid_type_error: '"selectUserFields" precisa ser um array de strings.',
+      required_error: '"selectUserFields" é obrigatório.',
+    },
+  ),
 });

--- a/tests/models/user.test.ts
+++ b/tests/models/user.test.ts
@@ -25,7 +25,8 @@ describe('> models/user', () => {
       expect(result).toStrictEqual({
         data: null,
         error: {
-          message: 'A propriedade "id" deve ser um UUID',
+          message: '"userId" precisa ser um UUID válido.',
+          fields: ['userId'],
         },
       });
     });
@@ -78,7 +79,8 @@ describe('> models/user', () => {
       expect(result).toStrictEqual({
         data: null,
         error: {
-          message: 'A propriedade "id" deve ser uma string',
+          message: '"userId" precisa ser uma string.',
+          fields: ['userId'],
         },
       });
     });
@@ -91,7 +93,8 @@ describe('> models/user', () => {
       expect(result).toStrictEqual({
         data: null,
         error: {
-          message: 'A propriedade "id" é obrigatória',
+          message: '"userId" é obrigatório.',
+          fields: ['userId'],
         },
       });
     });
@@ -153,7 +156,8 @@ describe('> models/user', () => {
         data: null,
         error: {
           message:
-            'A propriedade "select" deve conter apenas propriedades válidas',
+            '"selectUserFields" precisa conter apenas propriedades válidas.',
+          fields: ['selectUserFields'],
         },
       });
     });

--- a/tests/models/validator.test.ts
+++ b/tests/models/validator.test.ts
@@ -1225,4 +1225,155 @@ describe('> models/validator', () => {
       });
     });
   });
+
+  describe('Testing "selectUserFields"', () => {
+    test('Providing valid value to optional parameter', () => {
+      const result = validator(
+        {
+          selectUserFields: ['name', 'email', 'userName'],
+        },
+        {
+          selectUserFields: 'optional',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: {
+          selectUserFields: ['name', 'email', 'userName'],
+        },
+        error: null,
+      });
+    });
+
+    test('Providing undefined to optional parameter', () => {
+      const result = validator(
+        {
+          selectUserFields: undefined,
+        },
+        {
+          selectUserFields: 'optional',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: {},
+        error: null,
+      });
+    });
+
+    test('Providing a invalid property to optional parameter', () => {
+      const result = validator(
+        {
+          selectUserFields: ['name', 'email', 'userName', 'invalid'],
+        },
+        {
+          selectUserFields: 'optional',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: null,
+        error: {
+          message:
+            '"selectUserFields" precisa conter apenas propriedades válidas.',
+          fields: ['selectUserFields'],
+        },
+      });
+    });
+
+    test('Providing invalid type value to optional parameter', () => {
+      const result = validator(
+        {
+          selectUserFields: 123 as any,
+        },
+        {
+          selectUserFields: 'optional',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: null,
+        error: {
+          message: '"selectUserFields" precisa ser um array de strings.',
+          fields: ['selectUserFields'],
+        },
+      });
+    });
+
+    test('Providing valid value to required parameter', () => {
+      const result = validator(
+        {
+          selectUserFields: ['name', 'email', 'userName'],
+        },
+        {
+          selectUserFields: 'required',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: {
+          selectUserFields: ['name', 'email', 'userName'],
+        },
+        error: null,
+      });
+    });
+
+    test('Providing undefined to required parameter', () => {
+      const result = validator(
+        {
+          selectUserFields: undefined,
+        },
+        {
+          selectUserFields: 'required',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: null,
+        error: {
+          message: '"selectUserFields" é obrigatório.',
+          fields: ['selectUserFields'],
+        },
+      });
+    });
+
+    test('Providing a invalid property to required parameter', () => {
+      const result = validator(
+        {
+          selectUserFields: ['name', 'email', 'userName', 'invalid'],
+        },
+        {
+          selectUserFields: 'required',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: null,
+        error: {
+          message:
+            '"selectUserFields" precisa conter apenas propriedades válidas.',
+          fields: ['selectUserFields'],
+        },
+      });
+    });
+
+    test('Providing invalid type value to required parameter', () => {
+      const result = validator(
+        {
+          selectUserFields: 123 as any,
+        },
+        {
+          selectUserFields: 'required',
+        },
+      );
+
+      expect(result).toStrictEqual({
+        data: null,
+        error: {
+          message: '"selectUserFields" precisa ser um array de strings.',
+          fields: ['selectUserFields'],
+        },
+      });
+    });
+  });
 });


### PR DESCRIPTION
- With this PR, we have finished the centralization of application inputs and fields.

- Now we have a global validator function that has all application field types.