### PR TITLE
[`authentication`]: fixed signout functionality when `accessToken` is not valid

### DIFF
--- a/models/authentication.ts
+++ b/models/authentication.ts
@@ -1,6 +1,5 @@
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
-import { cookies } from 'next/headers';
 
 import { ForgetPasswordEmail } from '@/components/email-templates/ForgetPassword';
 import { Welcome } from '@/components/email-templates/Welcome';
@@ -8,7 +7,6 @@ import { AuthenticationDataSource } from '@/data/authentication';
 import { createUserDataSource } from '@/data/user';
 import { emailService } from '@/models/email';
 import { ValidationSchema, validator } from '@/models/validator';
-import { constants } from '@/src/utils/constants';
 import { env } from '@/src/utils/env';
 import { Failure, Success, operationResult } from '@/src/utils/operationResult';
 
@@ -234,7 +232,6 @@ function verifyAccessToken({ accessToken }: VerifyAccessTokenProps) {
 
     return payload as Payload;
   } catch {
-    cookies().delete(constants.accessTokenKey);
     return null;
   }
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -16,8 +16,10 @@ async function signOut() {
   return redirect('/auth/signin');
 }
 
-function checkAccessToken() {
-  const accessToken = cookies().get(constants.accessTokenKey)?.value;
+export default async function Page() {
+  const cookieStore = cookies();
+
+  const accessToken = cookieStore.get(constants.accessTokenKey)?.value;
   const payload = auth.verifyAccessToken({
     accessToken,
   });
@@ -25,12 +27,6 @@ function checkAccessToken() {
   if (!payload) {
     return redirect('/auth/signin');
   }
-
-  return payload;
-}
-
-export default async function Page() {
-  const payload = checkAccessToken();
 
   const userDataSource = createUserDataSource();
   const { data } = await user.findById(userDataSource, {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,6 +32,7 @@ export default function RootLayout({
           defaultTheme="system"
           enableSystem
           disableTransitionOnChange
+          storageKey={constants.themeKey}
         >
           {children}
         </ThemeProvider>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,3 +1,4 @@
+import jwt from 'jsonwebtoken';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { constants } from './utils/constants';
@@ -5,6 +6,17 @@ import { constants } from './utils/constants';
 export function middleware(request: NextRequest) {
   const accessToken = request.cookies.get(constants.accessTokenKey)?.value;
   const { pathname } = request.nextUrl;
+
+  if (accessToken) {
+    try {
+      const payload = jwt.verify(accessToken, process.env.JWT_SECRET_KEY!);
+
+      return payload;
+    } catch {
+      request.cookies.delete(constants.accessTokenKey);
+      return NextResponse.next();
+    }
+  }
 
   const isAuthPath = pathname.startsWith('/auth');
   const isPrivatePath = pathname.startsWith('/dashboard');


### PR DESCRIPTION
## Problem
- When you are logged in and try to modify your accessToken (stored in cookies). 
![image](https://github.com/SouzaGabriel26/onde-ir/assets/66218607/9566c418-58a2-4d6a-b0c9-23c1f9a0849b)