### PR TITLE
Standardize return of server actions and add `Toaster` to give feedbacks

### DIFF
--- a/components/SubmitButton.tsx
+++ b/components/SubmitButton.tsx
@@ -1,19 +1,57 @@
 'use client';
 
-import { useFormStatus } from 'react-dom';
+import { redirect } from 'next/navigation';
+import { useEffect } from 'react';
+import { useFormState, useFormStatus } from 'react-dom';
+import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/Button';
+import { Failure, Success } from '@/src/utils/operationResult';
+
+type ActionResponse = Promise<
+  Success<{ message: string; redirectLink: string }> | Failure<unknown>
+>;
 
 type SubmitButtonProps = {
   children: React.ReactNode;
   className?: string;
+  action?: (formData: FormData) => ActionResponse;
 };
 
-export function SubmitButton({ className, children }: SubmitButtonProps) {
+export function SubmitButton({
+  className,
+  children,
+  action,
+}: SubmitButtonProps) {
   const { pending } = useFormStatus();
 
+  const [state, formAction] = useFormState(
+    async (_prev: unknown, formData: FormData) => {
+      return await action?.(formData);
+    },
+    null,
+  );
+
+  useEffect(() => {
+    if (!state) return;
+
+    const { data, error } = state;
+
+    if (data) {
+      toast.success(data.message);
+      redirect(data.redirectLink);
+    } else {
+      toast.error(error.message);
+    }
+  }, [state]);
+
   return (
-    <Button disabled={pending} type="submit" className={className}>
+    <Button
+      type="submit"
+      disabled={pending}
+      className={className}
+      formAction={formAction}
+    >
       {children}
     </Button>
   );

--- a/components/SubmitButton.tsx
+++ b/components/SubmitButton.tsx
@@ -9,7 +9,7 @@ import { Button } from '@/components/ui/Button';
 import { Failure, Success } from '@/src/utils/operationResult';
 
 type ActionResponse = Promise<
-  Success<{ message: string; redirectLink: string }> | Failure<unknown>
+  Success<{ message: string; redirectLink?: string }> | Failure
 >;
 
 type SubmitButtonProps = {
@@ -39,7 +39,7 @@ export function SubmitButton({
 
     if (data) {
       toast.success(data.message);
-      redirect(data.redirectLink);
+      data.redirectLink && redirect(data.redirectLink);
     } else {
       toast.error(error.message);
     }

--- a/components/ui/Sonner.tsx
+++ b/components/ui/Sonner.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useTheme } from 'next-themes';
+import { Toaster as Sonner } from 'sonner';
+
+type ToasterProps = React.ComponentProps<typeof Sonner>;
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = 'system' } = useTheme();
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps['theme']}
+      className="toaster group"
+      toastOptions={{
+        classNames: {
+          toast:
+            'group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg',
+          description: 'group-[.toast]:text-muted-foreground',
+          actionButton:
+            'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',
+          cancelButton:
+            'group-[.toast]:bg-muted group-[.toast]:text-muted-foreground',
+        },
+      }}
+      {...props}
+    />
+  );
+};
+
+export { Toaster };

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react": "^18",
     "react-dom": "^18",
     "resend": "^3.3.0",
+    "sonner": "^1.5.0",
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       resend:
         specifier: ^3.3.0
         version: 3.3.0
+      sonner:
+        specifier: ^1.5.0
+        version: 1.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.3)
@@ -3098,6 +3101,12 @@ packages:
   slice-ansi@7.1.0:
     resolution: {integrity: sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==}
     engines: {node: '>=18'}
+
+  sonner@1.5.0:
+    resolution: {integrity: sha512-FBjhG/gnnbN6FY0jaNnqZOMmB73R+5IiyYAw8yBj7L54ER7HB3fOSE5OFiQiE2iXWxeXKvg6fIP4LtVppHEdJA==}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
 
   source-map-js@1.2.0:
     resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
@@ -6548,6 +6557,11 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.1
       is-fullwidth-code-point: 5.0.0
+
+  sonner@1.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   source-map-js@1.2.0: {}
 

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -1,6 +1,6 @@
+import { revalidatePath } from 'next/cache';
 import { cookies } from 'next/headers';
 import Link from 'next/link';
-import { redirect } from 'next/navigation';
 
 import { SubmitButton } from '@/components/SubmitButton';
 import { Input } from '@/components/ui/Input';
@@ -8,6 +8,7 @@ import { createAuthenticationDataSource } from '@/data/authentication';
 import { auth, SignInProps, SignInResponse } from '@/models/authentication';
 import { constants } from '@/src/utils/constants';
 import { form } from '@/src/utils/form';
+import { operationResult } from '@/src/utils/operationResult';
 
 let signInResponse: SignInResponse;
 
@@ -28,9 +29,18 @@ async function signInAction(formData: FormData) {
       expires: new Date(Date.now() + sevenDaysInMilliseconds),
       httpOnly: true,
     });
+
+    return operationResult.success({
+      message: 'Login efetuado com sucesso!',
+      redirectLink: '/dashboard',
+    });
   }
 
-  return redirect('/dashboard');
+  revalidatePath('/auth/signin');
+
+  return operationResult.failure({
+    message: signInResponse.error.message,
+  });
 }
 
 type Props = {
@@ -74,7 +84,7 @@ export default function Page({ searchParams }: Props) {
           autoComplete="current-password"
           error={auth.setInputError('password', signInResponse)}
         />
-        <SubmitButton>Entrar</SubmitButton>
+        <SubmitButton action={signInAction}>Entrar</SubmitButton>
       </form>
 
       <p className="text-center text-sm text-gray-400">

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -1,12 +1,12 @@
 import { revalidatePath } from 'next/cache';
 import Link from 'next/link';
-import { redirect } from 'next/navigation';
 
 import { SubmitButton } from '@/components/SubmitButton';
 import { Input } from '@/components/ui/Input';
 import { createAuthenticationDataSource } from '@/data/authentication';
 import { auth, SignUpProps, SignUpResponse } from '@/models/authentication';
 import { form } from '@/src/utils/form';
+import { operationResult } from '@/src/utils/operationResult';
 
 let signUpResponse: SignUpResponse;
 
@@ -21,10 +21,17 @@ async function signUpAction(formData: FormData) {
   if (signUpResponse.data) {
     const { userName } = signUpResponse.data;
 
-    redirect(`/auth/signin?userName=${userName}`);
+    return operationResult.success({
+      message: 'Usuário cadastrado com sucesso!',
+      redirectLink: `/auth/signin?userName=${userName}`,
+    });
   }
 
-  return revalidatePath('/auth/signup');
+  revalidatePath('/auth/signup');
+
+  return operationResult.failure({
+    message: signUpResponse.error.message,
+  });
 }
 
 export default function Page() {
@@ -83,7 +90,7 @@ export default function Page() {
           autoComplete="off"
           error={auth.setInputError('confirmPassword', signUpResponse)}
         />
-        <SubmitButton>Cadastrar</SubmitButton>
+        <SubmitButton action={signUpAction}>Cadastrar</SubmitButton>
       </form>
     </div>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,8 +2,10 @@ import type { Metadata } from 'next';
 import { cookies } from 'next/headers';
 
 import { ThemeProvider } from '@/components/ThemeProvider';
+import { Toaster } from '@/components/ui/Sonner';
 
 import { constants } from '../utils/constants';
+
 import './globals.css';
 
 export const metadata: Metadata = {
@@ -34,6 +36,7 @@ export default function RootLayout({
           disableTransitionOnChange
           storageKey={constants.themeKey}
         >
+          <Toaster />
           {children}
         </ThemeProvider>
       </body>


### PR DESCRIPTION
- This PR aims to give more structure to `server actions` used in the project. By now it's only implemented in  `signIn` and `signUp` actions, but i have centralized the logic in `SubmitButton`. With this, I will easily change the others.

Basically i added a `useFormState` (a Hook that allows you to update state based on the result of a form action) in the  `submitButton` to showup the `Toast` with success or error message. This hook receives a typed function from props (custom server action).


## Links: 
- https://react.dev/reference/react/useActionState


closes #92
