### PR TITLE
[`emailService`]: moves email services to be sended in `server actions` 

### DIFF
--- a/models/authentication.ts
+++ b/models/authentication.ts
@@ -1,11 +1,8 @@
 import bcrypt from 'bcrypt';
 import { jwtVerify, SignJWT } from 'jose';
 
-import { ForgetPasswordEmail } from '@/components/email-templates/ForgetPassword';
-import { Welcome } from '@/components/email-templates/Welcome';
 import { AuthenticationDataSource } from '@/data/authentication';
 import { createUserDataSource } from '@/data/user';
-import { emailService } from '@/models/email';
 import { ValidationSchema, validator } from '@/models/validator';
 import { env } from '@/src/utils/env';
 import { Failure, operationResult, Success } from '@/src/utils/operationResult';
@@ -152,16 +149,6 @@ async function signUp(
     userName,
   });
 
-  if (process.env.NODE_ENV !== 'test') {
-    await emailService.sendWelcomeMessage({
-      from: 'Onde Ir <onboarding@resend.dev>',
-      to: email,
-      content: Welcome({
-        userFirstname: name,
-      }),
-    });
-  }
-
   return operationResult.success({ email, name, userName });
 }
 
@@ -278,19 +265,9 @@ async function forgetPassword(
       resetPasswordToken: forgetPasswordToken,
     });
 
-  if (process.env.NODE_ENV !== 'test') {
-    await emailService.sendResetPasswordEmail({
-      from: 'Onde Ir <onboarding@resend.dev>',
-      to: email,
-      content: ForgetPasswordEmail({
-        userFirstname: userFoundByEmail.name,
-        resetPasswordTokenId,
-      }),
-    });
-  }
-
   return operationResult.success({
     resetPasswordTokenId,
+    name: userFoundByEmail.name,
   });
 }
 

--- a/src/app/auth/forget-password/page.tsx
+++ b/src/app/auth/forget-password/page.tsx
@@ -1,6 +1,7 @@
 import { revalidatePath } from 'next/cache';
 import Link from 'next/link';
 
+import { ForgetPasswordEmail } from '@/components/email-templates/ForgetPassword';
 import { SubmitButton } from '@/components/SubmitButton';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
@@ -10,6 +11,7 @@ import {
   ForgetPasswordInput,
   ForgetPasswordOutput,
 } from '@/models/authentication';
+import { emailService } from '@/models/email';
 import { form } from '@/src/utils/form';
 import { operationResult } from '@/src/utils/operationResult';
 
@@ -30,6 +32,16 @@ async function forgetPassword(formData: FormData) {
 
   if (responseMessage.data) {
     successMessage = { email };
+    const { resetPasswordTokenId, name } = responseMessage.data;
+
+    await emailService.sendResetPasswordEmail({
+      from: 'Onde Ir <onboarding@resend.dev>',
+      to: email,
+      content: ForgetPasswordEmail({
+        userFirstname: name,
+        resetPasswordTokenId,
+      }),
+    });
 
     revalidatePath('/auth/forget-password');
 

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -1,10 +1,12 @@
 import { revalidatePath } from 'next/cache';
 import Link from 'next/link';
 
+import { Welcome } from '@/components/email-templates/Welcome';
 import { SubmitButton } from '@/components/SubmitButton';
 import { Input } from '@/components/ui/Input';
 import { createAuthenticationDataSource } from '@/data/authentication';
 import { auth, SignUpProps, SignUpResponse } from '@/models/authentication';
+import { emailService } from '@/models/email';
 import { form } from '@/src/utils/form';
 import { operationResult } from '@/src/utils/operationResult';
 
@@ -19,7 +21,15 @@ async function signUpAction(formData: FormData) {
   signUpResponse = await auth.signUp(authDataSource, sanitizedData);
 
   if (signUpResponse.data) {
-    const { userName } = signUpResponse.data;
+    const { userName, email, name } = signUpResponse.data;
+
+    await emailService.sendWelcomeMessage({
+      from: 'Onde Ir <onboarding@resend.dev>',
+      to: email,
+      content: Welcome({
+        userFirstname: name,
+      }),
+    });
 
     return operationResult.success({
       message: 'Usuário cadastrado com sucesso!',

--- a/tests/models/auth.test.ts
+++ b/tests/models/auth.test.ts
@@ -396,6 +396,7 @@ describe('> models/authentication', () => {
       expect(result).toStrictEqual({
         error: null,
         data: {
+          name: 'Gabriel',
           resetPasswordTokenId: expect.any(String),
         },
       });


### PR DESCRIPTION
- This PR implements the issue #100.

Before, the email was being sended directly in models like `signUp`﻿ and `forgetPassword` methods. But now, they are being sending in server actions, in case of success.
