### PR TITLE
Implements `/dashboard/posts/[id]` page with dynamically data fetch and adjusts database

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  }
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -12,7 +12,7 @@ export default async function Page() {
   const placeDataSource = createPlaceDataSource();
   const { data: places } = await place.findAll(placeDataSource, {
     where: {
-      approved: 'true',
+      status: 'APPROVED',
     },
   });
 

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/Button';
 import { createPlaceDataSource } from '@/data/place';
 import { place } from '@/models/place';
 import { verify } from '@/utils/verify';
+import type { Route } from 'next';
 
 export default async function Page() {
   const { error: userNotAuthenticated } = await verify.loggedUser();
@@ -47,6 +48,7 @@ export default async function Page() {
       >
         {places?.map((place) => (
           <ImageCard
+            href={`/dashboard/posts/${place.id}` as Route}
             key={place.id}
             title={place.name}
             alt={`foto de ${place.name}`}

--- a/app/dashboard/posts/[id]/page.tsx
+++ b/app/dashboard/posts/[id]/page.tsx
@@ -1,11 +1,139 @@
+import { Button } from '@/components/ui/Button';
+import { createPlaceDataSource } from '@/data/place';
+import { createUserDataSource } from '@/data/user';
+import { place } from '@/models/place';
+import { sanitizeClassName } from '@/utils/sanitizeClassName';
+import { verify } from '@/utils/verify';
+import Image from 'next/image';
+import { RedirectType, redirect } from 'next/navigation';
+
 type PageProps = {
   params: {
     id: string;
   };
 };
 
-export default function Page({ params }: PageProps) {
+export default async function Page({ params }: PageProps) {
   const { id: postId } = params;
 
-  return <div>Status do post {postId}</div>;
+  const placeDataSource = createPlaceDataSource();
+  const { data: loggedUser } = await verify.loggedUser();
+
+  const { data: postFound, error } = await place.findById(
+    placeDataSource,
+    postId,
+  );
+  if (error) {
+    redirect('/dashboard', RedirectType.replace);
+  }
+
+  const isOwner = loggedUser?.id === postFound.created_by;
+  const isAdmin = loggedUser?.userRole === 'ADMIN';
+
+  if (postFound.status === 'PENDING') {
+    if (!loggedUser || (!isOwner && !isAdmin)) {
+      redirect('/dashboard', RedirectType.replace);
+    }
+  }
+
+  const categories = await placeDataSource.findCategories();
+  const postCategory = categories.find(
+    (category) => category.id === postFound.category_id,
+  );
+
+  const userDataSource = createUserDataSource();
+  const reviewedBy = await userDataSource.findById({
+    id: postFound.reviewed_by!,
+    select: ['name'],
+  });
+
+  return (
+    <div className="w-full space-y-6 pb-2">
+      <div className="w-full flex flex-col md:flex-row gap-4 justify-between">
+        <h2 className="text-3xl md:text-center">Foto(s) de {postFound.name}</h2>
+
+        {loggedUser?.userRole === 'ADMIN' && postFound.status === 'PENDING' && (
+          <div className="space-x-2">
+            <Button>Aprovar</Button>
+
+            <Button variant="destructive">Rejeitar</Button>
+          </div>
+        )}
+      </div>
+
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fill, minmax(400px, 1fr))',
+          placeItems: 'center',
+          gap: '1rem',
+        }}
+      >
+        {postFound.images.map((url, index) => (
+          <div
+            key={`foto-${postFound.name}-${index}`}
+            className={sanitizeClassName(
+              'relative',
+              'h-44 w-64 md:h-64 md:w-96',
+            )}
+          >
+            <Image
+              fill
+              src={url}
+              alt={`Foto ${index + 1} de ${postFound.name}`}
+              sizes="100%"
+              className="rounded-[20px] object-cover"
+            />
+          </div>
+        ))}
+      </div>
+
+      <div className="md:w-fit md:mx-auto">
+        <h2 className="text-3xl md:text-center mb-2">Sobre o local:</h2>
+
+        <TextInfo label="Nome" value={postFound.name} />
+
+        <TextInfo label="País" value={postFound.country} />
+
+        <TextInfo label="Estado" value={postFound.state} />
+
+        <TextInfo label="Cidade" value={postFound.city} />
+
+        <TextInfo label="Rua" value={postFound.street} />
+
+        <TextInfo label="Número" value={String(postFound.num_place)} />
+
+        <TextInfo label="Complemento" value={postFound.complement ?? '-'} />
+
+        <TextInfo label="Descrição" value={postFound.description ?? '-'} />
+
+        <TextInfo label="Categoria" value={postCategory?.name ?? '-'} />
+
+        <TextInfo label="Status" value={postFound.status} />
+
+        {postFound.status !== 'PENDING' && (
+          <TextInfo label="Revisado por" value={reviewedBy?.name ?? '-'} />
+        )}
+
+        <TextInfo
+          label="Criado em"
+          value={new Date(postFound.created_at).toLocaleDateString()}
+        />
+
+        <TextInfo
+          label="Atualizado em"
+          value={new Date(postFound.updated_at).toLocaleDateString()}
+        />
+      </div>
+    </div>
+  );
+}
+
+function TextInfo({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex space-x-2">
+      <span className="text-slate-500">{label}: </span>
+      <span>{value}</span>
+    </div>
+  );
 }

--- a/app/dashboard/posts/_components/ImageUpload.tsx
+++ b/app/dashboard/posts/_components/ImageUpload.tsx
@@ -97,7 +97,12 @@ export function ImageUpload({ actionOnUpload }: ImageUploadProps) {
         className="self-end"
         type="button"
         onClick={handleUpload}
-        disabled={isLoading || !uploads.length || hasSomeInvalidFileType}
+        disabled={
+          isLoading ||
+          !uploads.length ||
+          hasSomeInvalidFileType ||
+          uploads.length > 4
+        }
       >
         {isLoading && <Loader2Icon className="mr-2 animate-spin" />}
         Enviar
@@ -128,7 +133,7 @@ export function Dropzone({ onDrop }: DropzoneProps) {
         isDragActive && 'bg-primary-foreground',
       )}
     >
-      <input {...getInputProps()} />
+      <input accept="image/png, image/jpg, image/jpeg" {...getInputProps()} />
 
       <div className="flex h-full flex-col items-center justify-center">
         <PackageOpenIcon className="mb-2 size-12" />
@@ -150,6 +155,13 @@ function FilesPreview({ uploads, onDeleteUpload }: FilesPreviewProps) {
   return (
     <div className="space-y-2">
       <span className="text-xl">Arquivos selecionados: {uploads.length}</span>
+
+      {uploads.length > 4 && (
+        <span className="text-sm block text-destructive">
+          O número máximo de arquivos permitidos é 4
+        </span>
+      )}
+
       <div className="max-h-80 space-y-2 overflow-y-auto rounded-md p-2">
         {uploads.map(({ file, progress }) => (
           <FileItem

--- a/app/dashboard/posts/layout.tsx
+++ b/app/dashboard/posts/layout.tsx
@@ -30,7 +30,7 @@ export default async function Layout({ children }: Props) {
         </Link>
       </div>
 
-      <div className="flex flex-grow flex-col items-center rounded-md border p-4">
+      <div className="flex flex-grow flex-col overflow-y-auto items-center rounded-md border p-4">
         {children}
       </div>
     </section>

--- a/biome.json
+++ b/biome.json
@@ -35,7 +35,8 @@
   },
   "javascript": {
     "formatter": {
-      "quoteStyle": "single"
+      "quoteStyle": "single",
+      "trailingCommas": "all"
     }
   }
 }

--- a/components/ImageCard.tsx
+++ b/components/ImageCard.tsx
@@ -2,6 +2,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 
 import { sanitizeClassName } from '@/utils/sanitizeClassName';
+import type { Route } from 'next';
 
 type ImageCardProps = {
   src: string;
@@ -10,6 +11,7 @@ type ImageCardProps = {
   description: string;
   variant?: 'md' | 'lg';
   className?: string;
+  href?: Route;
 };
 
 export function ImageCard({
@@ -19,11 +21,12 @@ export function ImageCard({
   description,
   variant = 'lg',
   src,
+  href,
 }: ImageCardProps) {
   return (
     <Link
       title={title}
-      href="#"
+      href={href ?? '#'}
       className={sanitizeClassName(
         'h-fit w-fit rounded-[20px] shadow',
         className,

--- a/data/place.ts
+++ b/data/place.ts
@@ -2,6 +2,8 @@ import { database } from '@/infra/database';
 import type { CreatePlaceImagesInput, CreatePlaceInput } from '@/models/place';
 import { sql } from '@/utils/syntax-highlighting';
 
+export type PlaceStatus = 'APPROVED' | 'PENDING' | 'REJECTED';
+
 export type PlaceDataSource = ReturnType<typeof createPlaceDataSource>;
 
 export function createPlaceDataSource() {
@@ -19,7 +21,7 @@ export function createPlaceDataSource() {
     limit: number;
     offset: number;
     where?: {
-      approved?: 'true' | 'false';
+      status?: PlaceStatus;
       state?: string;
       name?: string;
     };
@@ -38,10 +40,11 @@ export function createPlaceDataSource() {
     category_id: string;
     latitude?: number;
     longitude?: number;
-    approved: boolean;
-    approved_by?: string;
+    status: PlaceStatus;
+    reviewed_by?: string;
     created_by: string;
     created_at: Date;
+    updated_at: Date;
     images: string[];
   };
 
@@ -94,11 +97,9 @@ export function createPlaceDataSource() {
         query.values.push(where.name);
       }
 
-      if (where?.approved) {
-        const approvedWhereStatement =
-          where.approved === 'true' ? sql`approved` : sql`NOT approved`;
-
-        whereClauses.push(approvedWhereStatement);
+      if (where?.status) {
+        whereClauses.push(sql`status = `.concat(`$${++index}`));
+        query.values.push(where.status);
       }
 
       let whereClauseText = '';

--- a/infra/queries/01-populate-users-table.sql
+++ b/infra/queries/01-populate-users-table.sql
@@ -8,16 +8,16 @@ INSERT INTO users
   )
 VALUES
 	(
-    'janedoe@email.com',
-    'Jane Doe',
-    'janeDoe',
+    'user@email.com',
+    'Normal user',
+    'normal_user',
     'USER',
     '$2b$10$Vtq78yo4RxbWPtARY6R7CO2vVeGu1Nd4XASIhxB/PylfTL1/Bf3TG'
   ),
   (
-    'gabriel@email.com',
-    'Gabriel',
-    'gbsouza',
+    'admin@email.com',
+    'Admin user',
+    'admin_user',
     'ADMIN',
     '$2b$10$Vtq78yo4RxbWPtARY6R7CO2vVeGu1Nd4XASIhxB/PylfTL1/Bf3TG'
   );

--- a/infra/queries/03-populate-places-table.sql
+++ b/infra/queries/03-populate-places-table.sql
@@ -11,8 +11,8 @@ INSERT INTO places
     category_id,
     latitude,
     longitude,
-    approved,
-    approved_by,
+    status,
+    reviewed_by,
     created_by
   )
 VALUES
@@ -28,7 +28,7 @@ VALUES
     (SELECT id FROM categories WHERE name = 'restaurantes'),
     -20.3155,
     -40.3128,
-    TRUE,
+    'APPROVED',
     (SELECT id FROM users WHERE user_role = 'ADMIN' LIMIT 1),
     (SELECT id FROM users WHERE user_role = 'ADMIN' LIMIT 1)
   ),
@@ -44,7 +44,7 @@ VALUES
     (SELECT id FROM categories WHERE name = 'restaurantes'),
     -20.3155,
     -40.2969,
-    TRUE,
+    'APPROVED',
     (SELECT id FROM users WHERE user_role = 'ADMIN' LIMIT 1),
     (SELECT id FROM USERS WHERE user_role = 'USER' LIMIT 1)
   ),
@@ -60,8 +60,8 @@ VALUES
     (SELECT id FROM categories WHERE name = 'restaurantes'),
     -20.3274,
     -40.2922,
-    FALSE,
-    NULL,
+    'REJECTED',
+    (SELECT id FROM users WHERE user_role = 'ADMIN' LIMIT 1),
     (SELECT id FROM users WHERE user_role = 'USER' LIMIT 1)
   ),
   (
@@ -76,7 +76,7 @@ VALUES
     (SELECT id FROM categories WHERE name = 'restaurantes'),
     -20.3155,
     -40.3128,
-    FALSE,
+    'PENDING',
     NULL,
     (SELECT id FROM users WHERE user_role = 'USER' LIMIT 1)
   );

--- a/infra/queries/04-populate-places-ratings-table.sql
+++ b/infra/queries/04-populate-places-ratings-table.sql
@@ -6,7 +6,7 @@ WITH approved_places as (
   FROM
     places
   WHERE
-    approved
+    status = 'APPROVED'
 )
 INSERT INTO place_ratings
 	(

--- a/infra/queries/05-populate-places-comments.sql
+++ b/infra/queries/05-populate-places-comments.sql
@@ -7,14 +7,14 @@ INSERT INTO place_comments
   )
 VALUES
 	(
-    (SELECT id FROM places WHERE approved AND name = 'Churrascaria Espeto de Ouro'),
-    (SELECT id FROM users WHERE name = 'Gabriel'),
+    (SELECT id FROM places WHERE status = 'APPROVED' AND name = 'Churrascaria Espeto de Ouro'),
+    (SELECT id FROM users WHERE name = 'Admin user'),
     NULL,
     'Achei interessante este local, frequento bastante!'
   ),
   (
-    (SELECT id FROM places WHERE approved AND name = 'Café Bamboo'),
-    (SELECT id from users WHERE name = 'Jane Doe'),
+    (SELECT id FROM places WHERE status = 'APPROVED' AND name = 'Café Bamboo'),
+    (SELECT id from users WHERE name = 'Normal user'),
     NULL,
     'Um ótimo café'
   );

--- a/infra/queries/drop-schema-and-populate-tables.sql
+++ b/infra/queries/drop-schema-and-populate-tables.sql
@@ -5,6 +5,7 @@ CREATE SCHEMA public;
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 CREATE TYPE ROLES AS ENUM ('ADMIN', 'USER');
+CREATE TYPE STATUS AS ENUM ('PENDING', 'APPROVED', 'REJECTED');
 
 CREATE TABLE users (
   id UUID DEFAULT uuid_generate_v4() CONSTRAINT users_pkey PRIMARY KEY,
@@ -45,8 +46,8 @@ CREATE TABLE places (
   category_id UUID NOT NULL REFERENCES categories(id),
   latitude DOUBLE PRECISION,
   longitude DOUBLE PRECISION,
-  approved BOOLEAN DEFAULT FALSE,
-  approved_by UUID REFERENCES users(id),
+  status STATUS DEFAULT('PENDING'),
+  reviewed_by UUID REFERENCES users(id),
   created_by UUID NOT NULL REFERENCES users(id),
   created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT (NOW() AT TIME ZONE 'UTC'),
   updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT (NOW() AT TIME ZONE 'UTC')
@@ -74,7 +75,7 @@ CREATE TABLE place_comments (
   place_id UUID NOT NULL REFERENCES places(id) ON DELETE CASCADE,
   user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
   parent_comment_id UUID REFERENCES place_comments(id) ON DELETE CASCADE,
-  description VARCHAR(255),
+  description VARCHAR(255) NOT NULL,
   created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT (NOW() AT TIME ZONE 'UTC'),
   updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT (NOW() AT TIME ZONE 'UTC')
 );
@@ -83,6 +84,7 @@ CREATE TABLE place_comment_likes (
   id UUID DEFAULT uuid_generate_v4() CONSTRAINT place_comment_likes_pkey PRIMARY KEY,
   comment_id UUID NOT NULL REFERENCES place_comments(id) ON DELETE CASCADE,
   user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT (NOW() AT TIME ZONE 'UTC'),
 
   UNIQUE (comment_id, user_id)
 );

--- a/models/place.ts
+++ b/models/place.ts
@@ -6,6 +6,7 @@ import { type ValidationSchema, validator } from './validator';
 
 export const place = Object.freeze({
   findAll,
+  findById,
   create,
   createImages,
 });
@@ -58,6 +59,25 @@ async function findAll(
   return operationResult.success(places);
 }
 
+async function findById(placeDataSource: PlaceDataSource, id: string) {
+  const validationResult = validator(
+    { place_id: id },
+    { place_id: 'required' },
+  );
+
+  if (validationResult.error) return validationResult;
+
+  const place = await placeDataSource.findById(id);
+
+  if (!place) {
+    return operationResult.failure({
+      message: 'Local não encontrado.',
+      fields: ['place_id'],
+    });
+  }
+
+  return operationResult.success(place);
+}
 export type CreatePlaceInput = {
   name: string;
   country: string;
@@ -161,7 +181,7 @@ async function createImages(
 
   if (error) return operationResult.failure(error);
 
-  const placeExists = await placeDataSource.findOneById(input.place_id);
+  const placeExists = await placeDataSource.findById(input.place_id);
   if (!placeExists) {
     return operationResult.failure({
       message: 'Local não encontrado.',

--- a/models/place.ts
+++ b/models/place.ts
@@ -1,4 +1,4 @@
-import type { PlaceDataSource } from '@/data/place';
+import type { PlaceDataSource, PlaceStatus } from '@/data/place';
 import { createUserDataSource } from '@/data/user';
 import { operationResult } from '@/utils/operationResult';
 
@@ -14,7 +14,7 @@ type FindAllInput = {
   page?: ValidationSchema['page'];
   limit?: ValidationSchema['limit'];
   where?: {
-    approved?: 'true' | 'false';
+    status?: PlaceStatus;
     state?: string;
     name?: string;
   };
@@ -33,12 +33,14 @@ async function findAll(
       limit: input.limit,
       state: input.where?.state,
       name: input.where?.name,
+      status: input.where?.status,
     },
     {
       limit: 'required',
       page: 'required',
       state: 'optional',
       name: 'optional',
+      status: 'optional',
     },
   );
 

--- a/models/validator.ts
+++ b/models/validator.ts
@@ -315,4 +315,15 @@ const schema = z.object({
     .uuid({
       message: '"created_by" precisa ser um UUID válido.',
     }),
+  status: z.enum(['APPROVED', 'PENDING', 'REJECTED'], {
+    errorMap: (issue) => {
+      const error = {
+        message: '"status" é obrigatório.',
+      };
+      if (issue.code === 'invalid_enum_value') {
+        error.message = '"status" deve ser APPROVED, PENDING ou REJECTED.';
+      }
+      return error;
+    },
+  }),
 });

--- a/tests/models/auth.test.ts
+++ b/tests/models/auth.test.ts
@@ -186,7 +186,7 @@ describe('> models/authentication', () => {
       const authDataSource = createAuthenticationDataSource();
 
       const input: SignUpProps = {
-        email: 'gabriel@email.com',
+        email: 'user@email.com',
         name: 'Gabriel',
         userName: 'gabrielNovo',
         password: '123456',
@@ -210,7 +210,7 @@ describe('> models/authentication', () => {
       const input: SignUpProps = {
         email: 'gabrie+1@email.com',
         name: 'Gabriel',
-        userName: 'gbsouza',
+        userName: 'normal_user',
         password: '123456',
         confirmPassword: '123456',
       };
@@ -312,7 +312,7 @@ describe('> models/authentication', () => {
       const authDataSource = createAuthenticationDataSource();
 
       const result = await auth.signIn(authDataSource, {
-        email: 'gabriel@email.com',
+        email: 'user@email.com',
         password: '123456',
       });
 

--- a/tests/models/password.test.ts
+++ b/tests/models/password.test.ts
@@ -64,7 +64,7 @@ describe('> models/password', () => {
     });
 
     test('Providing an existent "email"', async () => {
-      const existentEmail = 'gabriel@email.com';
+      const existentEmail = 'admin@email.com';
 
       const authDataSource = createAuthenticationDataSource();
       const result = await password.forgot(authDataSource, {
@@ -74,7 +74,7 @@ describe('> models/password', () => {
       expect(result).toStrictEqual({
         error: null,
         data: {
-          name: 'Gabriel',
+          name: 'Admin user',
           resetPasswordTokenId: expect.any(String),
         },
       });
@@ -83,7 +83,7 @@ describe('> models/password', () => {
 
   describe('Invoking "reset" method after calling "forgot"', () => {
     const uuid = randomUUID();
-    const userEmail = 'gabriel@email.com';
+    const userEmail = 'admin@email.com';
 
     test('Providing an empty object', async () => {
       const authDataSource = createAuthenticationDataSource();

--- a/tests/models/place.test.ts
+++ b/tests/models/place.test.ts
@@ -1,4 +1,4 @@
-import crypto, { randomUUID } from 'node:crypto';
+import crypto, { randomBytes, randomUUID } from 'node:crypto';
 
 import { createPlaceDataSource } from '@/data/place';
 import { database } from '@/infra/database';
@@ -642,6 +642,52 @@ describe('> models/place', () => {
       `);
 
       expect(placeImagesAfter?.rows.length).toBe(7);
+    });
+  });
+
+  describe('Invoking "findById" method', () => {
+    test('Providing valid place "id"', async () => {
+      const placeDataSource = createPlaceDataSource();
+      const categories = await placeDataSource.findCategories();
+      const name = randomBytes(10).toString('hex');
+
+      const createdBy = await getUserId();
+
+      const { data: createdPlace } = await place.create(placeDataSource, {
+        name,
+        category_id: categories[0].id,
+        city: 'Vila Velha',
+        country: 'Brasil',
+        created_by: createdBy,
+        state: 'ES',
+        street: 'Av. Hugo Musso',
+      });
+
+      const result = await place.findById(placeDataSource, createdPlace!.id);
+
+      expect(result).toStrictEqual({
+        error: null,
+        data: {
+          id: expect.any(String),
+          name,
+          country: 'Brasil',
+          state: 'ES',
+          city: 'Vila Velha',
+          street: 'Av. Hugo Musso',
+          num_place: null,
+          complement: null,
+          description: null,
+          category_id: expect.any(String),
+          latitude: null,
+          longitude: null,
+          status: 'PENDING',
+          reviewed_by: null,
+          created_by: createdBy,
+          created_at: expect.any(Date),
+          updated_at: expect.any(Date),
+          images: [],
+        },
+      });
     });
   });
 });

--- a/tests/models/place.test.ts
+++ b/tests/models/place.test.ts
@@ -35,8 +35,8 @@ describe('> models/place', () => {
             category_id: expect.any(String),
             latitude: -20.3274,
             longitude: -40.2922,
-            approved: false,
-            approved_by: null,
+            status: 'REJECTED',
+            reviewed_by: expect.any(String),
             created_by: expect.any(String),
             created_at: expect.anything(),
             updated_at: expect.anything(),
@@ -56,8 +56,8 @@ describe('> models/place', () => {
             category_id: expect.any(String),
             latitude: -20.3155,
             longitude: -40.2969,
-            approved: true,
-            approved_by: expect.any(String),
+            status: 'APPROVED',
+            reviewed_by: expect.any(String),
             created_by: expect.any(String),
             created_at: expect.anything(),
             updated_at: expect.anything(),
@@ -76,8 +76,8 @@ describe('> models/place', () => {
             category_id: expect.any(String),
             latitude: -20.3155,
             longitude: -40.3128,
-            approved: true,
-            approved_by: expect.any(String),
+            status: 'APPROVED',
+            reviewed_by: expect.any(String),
             created_by: expect.any(String),
             created_at: expect.anything(),
             updated_at: expect.anything(),
@@ -96,8 +96,8 @@ describe('> models/place', () => {
             category_id: expect.any(String),
             latitude: -20.3155,
             longitude: -40.3128,
-            approved: false,
-            approved_by: null,
+            status: 'PENDING',
+            reviewed_by: null,
             created_by: expect.any(String),
             created_at: expect.anything(),
             updated_at: expect.anything(),
@@ -163,11 +163,11 @@ describe('> models/place', () => {
       });
     });
 
-    test('Providing "where" with "approved" property as true', async () => {
+    test('Providing "where" with status equals to "APPROVED"', async () => {
       const placeDataSource = createPlaceDataSource();
       const result = await place.findAll(placeDataSource, {
         where: {
-          approved: 'true',
+          status: 'APPROVED',
         },
       });
 
@@ -188,8 +188,8 @@ describe('> models/place', () => {
             category_id: expect.any(String),
             latitude: -20.3155,
             longitude: -40.2969,
-            approved: true,
-            approved_by: expect.any(String),
+            status: 'APPROVED',
+            reviewed_by: expect.any(String),
             created_by: expect.any(String),
             created_at: expect.anything(),
             updated_at: expect.anything(),
@@ -208,8 +208,8 @@ describe('> models/place', () => {
             category_id: expect.any(String),
             latitude: -20.3155,
             longitude: -40.3128,
-            approved: true,
-            approved_by: expect.any(String),
+            status: 'APPROVED',
+            reviewed_by: expect.any(String),
             created_by: expect.any(String),
             created_at: expect.anything(),
             updated_at: expect.anything(),
@@ -219,11 +219,11 @@ describe('> models/place', () => {
       });
     });
 
-    test('Providing "where" with "approved" property as false', async () => {
+    test('Providing "where" status equals to "REJECTED"', async () => {
       const placeDataSource = createPlaceDataSource();
       const result = await place.findAll(placeDataSource, {
         where: {
-          approved: 'false',
+          status: 'REJECTED',
         },
       });
 
@@ -244,28 +244,8 @@ describe('> models/place', () => {
             category_id: expect.any(String),
             latitude: -20.3274,
             longitude: -40.2922,
-            approved: false,
-            approved_by: null,
-            created_by: expect.any(String),
-            created_at: expect.anything(),
-            updated_at: expect.anything(),
-            images: expect.any(Array),
-          },
-          {
-            id: expect.any(String),
-            name: 'Pizzaria do Zé',
-            country: 'Brasil',
-            state: 'RJ',
-            city: 'Rio de Janeiro',
-            street: 'Av. Jerônimo Monteiro',
-            num_place: 1234,
-            complement: null,
-            description: 'Pizzaria com variedade de sabores e promoções',
-            category_id: expect.any(String),
-            latitude: -20.3155,
-            longitude: -40.3128,
-            approved: false,
-            approved_by: null,
+            status: 'REJECTED',
+            reviewed_by: expect.any(String),
             created_by: expect.any(String),
             created_at: expect.anything(),
             updated_at: expect.anything(),
@@ -299,8 +279,8 @@ describe('> models/place', () => {
             category_id: expect.any(String),
             latitude: -20.3155,
             longitude: -40.3128,
-            approved: false,
-            approved_by: null,
+            status: 'PENDING',
+            reviewed_by: null,
             created_by: expect.any(String),
             created_at: expect.anything(),
             updated_at: expect.anything(),
@@ -351,8 +331,8 @@ describe('> models/place', () => {
             category_id: expect.any(String),
             latitude: -20.3274,
             longitude: -40.2922,
-            approved: false,
-            approved_by: null,
+            status: 'REJECTED',
+            reviewed_by: expect.any(String),
             created_by: expect.any(String),
             created_at: expect.anything(),
             updated_at: expect.anything(),
@@ -385,8 +365,8 @@ describe('> models/place', () => {
             category_id: expect.any(String),
             latitude: -20.3155,
             longitude: -40.3128,
-            approved: true,
-            approved_by: expect.any(String),
+            status: 'APPROVED',
+            reviewed_by: expect.any(String),
             created_by: expect.any(String),
             created_at: expect.anything(),
             updated_at: expect.anything(),
@@ -405,8 +385,8 @@ describe('> models/place', () => {
             category_id: expect.any(String),
             latitude: -20.3155,
             longitude: -40.3128,
-            approved: false,
-            approved_by: null,
+            status: 'PENDING',
+            reviewed_by: null,
             created_by: expect.any(String),
             created_at: expect.anything(),
             updated_at: expect.anything(),

--- a/tests/models/user.test.ts
+++ b/tests/models/user.test.ts
@@ -58,9 +58,9 @@ describe('> models/user', () => {
         error: null,
         data: {
           id: userIdFromDatabase,
-          email: 'janedoe@email.com',
-          name: 'Jane Doe',
-          userName: 'janeDoe',
+          email: 'user@email.com',
+          name: 'Normal user',
+          userName: 'normal_user',
           userRole: 'USER',
           createdAt: expect.any(String),
           updatedAt: expect.any(String),
@@ -112,9 +112,9 @@ describe('> models/user', () => {
       expect(foundUser).toStrictEqual({
         data: {
           id: userIdFromDatabase,
-          email: 'janedoe@email.com',
-          name: 'Jane Doe',
-          userName: 'janeDoe',
+          email: 'user@email.com',
+          name: 'Normal user',
+          userName: 'normal_user',
           userRole: 'USER',
           createdAt: expect.any(String),
           updatedAt: expect.any(String),
@@ -136,8 +136,8 @@ describe('> models/user', () => {
       expect(foundUser).toStrictEqual({
         error: null,
         data: {
-          name: 'Jane Doe',
-          email: 'janedoe@email.com',
+          name: 'Normal user',
+          email: 'user@email.com',
         },
       });
     });


### PR DESCRIPTION
## Context
- With this PR, it's possible to see the `post/[id]` page, fetching dynamically data by the `post_id`.
- It also has some validations, such as:
  - If the post `status` is `PENDING`, it will be available only to ADMIN users and the post owner.
  - If the post `status` is `PENDING` and the accessing is a `ADMIN`, it will appear buttons to `approve` or  `reject`

## Done
- Changed `approved` column to `status` enum type in `places` database table.
- Added editor `default formatter` to project config (biome.js).
- Adjusted `place.findAll` method to accept `status` parameter instead of `approved`.
- Implemented `findById` methodw.
- Limited how many images can be uploaded on the form.
- Implemented `/dashboard/posts/[id]` page with dynamically data fetching.

## Preview
[Gravação de tela de 13-10-2024 20:40:21.webm](https://github.com/user-attachments/assets/276bfe8f-cdb3-4853-9765-ad7801224b39)


## TODO
- Implement visualization of `PENDING` and `REJECTED` posts on `/dashboard` page
  - create table visualization for `ADMIN` users, with filter options like `created_by`, `status`, etc
  - create visualization of users `PENDING` and `REJECTED` posts, fetching only posts by `user_id`
- Implement a `transaction` method with `node-postgres`. 