### PR TITLE
Refactors all the `/auth` pages to use `useActionState` with `forms`

### DIFF
--- a/app/auth/forget-password/page.tsx
+++ b/app/auth/forget-password/page.tsx
@@ -1,14 +1,30 @@
+'use client';
+
 import Link from 'next/link';
 
 import { SubmitButton } from '@/components/SubmitButton';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { setInputError } from '@/utils/inputError';
+import { useActionState } from 'react';
+import {
+  type ForgetPasswordActionResponse,
+  forgetPasswordAction,
+} from './store';
 
-import { store } from './store';
+const initialState: ForgetPasswordActionResponse = {
+  data: null,
+  error: {
+    message: '',
+    fields: [],
+  },
+};
 
 export default function Page() {
-  const { responseMessage, successMessage } = store.getForgetPasswordResponse();
+  const [state, action, _isPending] = useActionState(
+    forgetPasswordAction,
+    initialState,
+  );
 
   return (
     <div className="space-y-4 px-5 md:w-96">
@@ -19,24 +35,26 @@ export default function Page() {
         Digite seu email para enviarmos as instruções de recuperação de senha
       </h2>
 
-      <form action={store.forgetPassword} className="flex flex-col space-y-3">
+      <form action={action} className="flex flex-col space-y-3">
         <Input
           id="email"
+          defaultValue={state.inputs?.email}
           placeholder="Email*"
+          type="email"
           name="email"
           required
           error={setInputError('email', {
-            fields: responseMessage?.error?.fields,
-            message: responseMessage?.error?.message,
+            fields: state?.error?.fields,
+            message: state?.error?.message,
           })}
         />
         <SubmitButton>Enviar</SubmitButton>
       </form>
 
-      {successMessage && (
+      {state.data?.name && (
         <>
           <p className="mt-4 text-center text-sm text-green-400">
-            Instruções enviadas para <strong>{successMessage.email}</strong>
+            Instruções enviadas para <strong>{state.inputs?.email}</strong>
           </p>
 
           <Button>

--- a/app/auth/reset-password/ResetPasswordForm.tsx
+++ b/app/auth/reset-password/ResetPasswordForm.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { SubmitButton } from '@/components/SubmitButton';
+import { Input } from '@/components/ui/Input';
+import { setInputError } from '@/utils/inputError';
+import Link from 'next/link';
+import { useActionState } from 'react';
+import { type ResetPasswordActionResponse, resetPasswordAction } from './store';
+
+const initialState: ResetPasswordActionResponse = {
+  data: {},
+  error: null,
+};
+
+export function ResetPasswordForm({ tokenId }: { tokenId: string }) {
+  const [state, action, _isPending] = useActionState(
+    resetPasswordAction,
+    initialState,
+  );
+
+  const hasAuthenticationError =
+    !state?.data && state?.error?.fields.length === 0;
+
+  if (hasAuthenticationError) {
+    return (
+      <div>
+        <h1>
+          Token inválido ou expirado. Por favor, solicite uma nova recuperação
+          de senha.
+        </h1>
+
+        <br />
+
+        <Link href="/auth/forget-password" className="underline">
+          Solicitar nova recuperação de senha
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      action={action}
+      key={Date.toString()}
+      className="flex flex-col space-y-3"
+    >
+      <Input
+        required
+        id="password"
+        defaultValue={state?.inputs?.password}
+        type="password"
+        name="password"
+        placeholder="Digite uma nova senha"
+        error={setInputError('password', {
+          fields: state?.error?.fields,
+          message: state?.error?.message.replace('password', 'senha'),
+        })}
+      />
+      <Input
+        required
+        id="confirmPassword"
+        defaultValue={state?.inputs?.confirmPassword}
+        type="password"
+        name="confirmPassword"
+        placeholder="Confirmação de senha"
+        error={setInputError('confirmPassword', {
+          fields: state?.error?.fields,
+          message: state?.error?.message.replace(
+            'confirmPassword',
+            'confirmação de senha',
+          ),
+        })}
+      />
+      <input type="hidden" value={tokenId} name="resetPasswordTokenId" />
+      <SubmitButton>Enviar</SubmitButton>
+    </form>
+  );
+}

--- a/app/auth/reset-password/page.tsx
+++ b/app/auth/reset-password/page.tsx
@@ -1,10 +1,4 @@
-import Link from 'next/link';
-
-import { SubmitButton } from '@/components/SubmitButton';
-import { Input } from '@/components/ui/Input';
-import { setInputError } from '@/utils/inputError';
-
-import { store } from './store';
+import { ResetPasswordForm } from './ResetPasswordForm';
 
 type Props = {
   searchParams: Promise<{
@@ -14,70 +8,14 @@ type Props = {
 
 export default async function Page(props: Props) {
   const searchParams = await props.searchParams;
-  const { responseMessage } = store.getResponseMessage();
 
   const { tokenId } = searchParams;
-
-  const hasAuthenticationError =
-    !responseMessage?.data && responseMessage?.error?.fields.length === 0;
-
-  if (hasAuthenticationError) {
-    return (
-      <div>
-        <h1>
-          Token inválido ou expirado. Por favor, solicite uma nova recuperação
-          de senha.
-        </h1>
-
-        <br />
-
-        <Link href="/auth/forget-password" className="underline">
-          Solicitar nova recuperação de senha
-        </Link>
-      </div>
-    );
-  }
 
   return (
     <div className="space-y-4 md:w-80">
       <h1>Atualização de senha</h1>
 
-      <form
-        action={store.resetPasswordAction}
-        key={Date.toString()}
-        className="flex flex-col space-y-3"
-      >
-        <Input
-          required
-          id="password"
-          type="password"
-          name="password"
-          placeholder="Digite uma nova senha"
-          error={setInputError('password', {
-            fields: responseMessage?.error?.fields,
-            message: responseMessage?.error?.message,
-          })}
-        />
-        <Input
-          required
-          id="confirmPassword"
-          type="password"
-          name="confirmPassword"
-          placeholder="Confirmação de senha"
-          error={setInputError('confirmPassword', {
-            fields: responseMessage?.error?.fields,
-            message: responseMessage?.error?.message,
-          })}
-        />
-        <input type="hidden" value={tokenId} name="resetPasswordTokenId" />
-        <SubmitButton>Enviar</SubmitButton>
-      </form>
-
-      {hasAuthenticationError && (
-        <p className="text-center text-red-400">
-          {responseMessage?.error?.message}
-        </p>
-      )}
+      <ResetPasswordForm tokenId={tokenId} />
     </div>
   );
 }

--- a/app/auth/signin/SigninForm.tsx
+++ b/app/auth/signin/SigninForm.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { SubmitButton } from '@/components/SubmitButton';
+import { Input } from '@/components/ui/Input';
+import { setInputError } from '@/utils/inputError';
+import { useActionState } from 'react';
+import { type SignInResponseAction, signInAction } from './store';
+
+const initialState: SignInResponseAction = {
+  data: null,
+  error: {
+    message: '',
+    fields: [],
+  },
+};
+
+export function SigninForm() {
+  const [state, action, _isPending] = useActionState(
+    signInAction,
+    initialState,
+  );
+
+  return (
+    <form action={action} className="flex flex-col gap-2">
+      <Input
+        placeholder="Email*"
+        id="email"
+        defaultValue={state.inputs?.email}
+        name="email"
+        type="email"
+        required
+        autoComplete="email"
+        error={setInputError('email', {
+          fields: state?.error?.fields,
+          message: state?.error?.message,
+        })}
+      />
+      <Input
+        placeholder="Senha*"
+        id="password"
+        defaultValue={state.inputs?.password}
+        name="password"
+        type="password"
+        required
+        autoComplete="current-password"
+        error={setInputError('password', {
+          fields: state?.error?.fields,
+          message: state?.error?.message.replace('password', 'senha'),
+        })}
+      />
+      <SubmitButton>Entrar</SubmitButton>
+    </form>
+  );
+}

--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -1,10 +1,6 @@
 import Link from 'next/link';
 
-import { SubmitButton } from '@/components/SubmitButton';
-import { Input } from '@/components/ui/Input';
-import { setInputError } from '@/utils/inputError';
-
-import { store } from './store';
+import { SigninForm } from './SigninForm';
 
 type Props = {
   searchParams: Promise<{
@@ -15,7 +11,6 @@ type Props = {
 
 export default async function Page(props: Props) {
   const searchParams = await props.searchParams;
-  const { signInResponse } = store.getSignInResponse();
 
   const { userName, redirect_reason } = searchParams;
 
@@ -47,32 +42,7 @@ export default async function Page(props: Props) {
         </Link>
       </p>
 
-      <form action={store.signInAction} className="flex flex-col gap-2">
-        <Input
-          placeholder="Email*"
-          id="email"
-          name="email"
-          required
-          autoComplete="email"
-          error={setInputError('email', {
-            fields: signInResponse?.error?.fields,
-            message: signInResponse?.error?.message,
-          })}
-        />
-        <Input
-          placeholder="Senha*"
-          id="password"
-          name="password"
-          type="password"
-          required
-          autoComplete="current-password"
-          error={setInputError('password', {
-            fields: signInResponse?.error?.fields,
-            message: signInResponse?.error?.message,
-          })}
-        />
-        <SubmitButton>Entrar</SubmitButton>
-      </form>
+      <SigninForm />
 
       <p className="text-center text-sm text-gray-400">
         Esqueceu sua senha?{' '}

--- a/app/auth/signup/SignupForm.tsx
+++ b/app/auth/signup/SignupForm.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { SubmitButton } from '@/components/SubmitButton';
+import { Input } from '@/components/ui/Input';
+import { setInputError } from '@/utils/inputError';
+import { useActionState } from 'react';
+import { type SignUpActionResponse, signUpAction } from './store';
+
+const initialState: SignUpActionResponse = {
+  data: null,
+  error: {
+    message: '',
+    fields: [],
+  },
+};
+
+export function SignupForm() {
+  const [state, action, _isPending] = useActionState(
+    signUpAction,
+    initialState,
+  );
+
+  return (
+    <form className="flex flex-col gap-3" action={action}>
+      <Input
+        required
+        id="name"
+        defaultValue={state.inputs?.name}
+        placeholder="Nome*"
+        name="name"
+        autoComplete="off"
+        error={setInputError('name', {
+          fields: state?.error?.fields,
+          message: state?.error?.message,
+        })}
+      />
+      <Input
+        required
+        id="email"
+        type="email"
+        defaultValue={state.inputs?.email}
+        placeholder="Email*"
+        name="email"
+        error={setInputError('email', {
+          fields: state?.error?.fields,
+          message: state?.error?.message,
+        })}
+      />
+      <Input
+        required
+        id="userName"
+        defaultValue={state.inputs?.userName}
+        placeholder="Username*"
+        name="userName"
+        autoComplete="off"
+        error={setInputError('userName', {
+          fields: state?.error?.fields,
+          message: state?.error?.message,
+        })}
+      />
+      <Input
+        required
+        id="password"
+        defaultValue={state.inputs?.password}
+        placeholder="Senha*"
+        type="password"
+        name="password"
+        autoComplete="off"
+        error={setInputError('password', {
+          fields: state?.error?.fields,
+          message: state?.error?.message.replace('password', 'senha'),
+        })}
+      />
+      <Input
+        required
+        id="confirmPassword"
+        defaultValue={state.inputs?.confirmPassword}
+        placeholder="Confirmar Senha*"
+        type="password"
+        name="confirmPassword"
+        autoComplete="off"
+        error={setInputError('confirmPassword', {
+          fields: state?.error?.fields,
+          message: state?.error?.message,
+        })}
+      />
+      <SubmitButton>Cadastrar</SubmitButton>
+    </form>
+  );
+}

--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -1,14 +1,8 @@
 import Link from 'next/link';
 
-import { SubmitButton } from '@/components/SubmitButton';
-import { Input } from '@/components/ui/Input';
-import { setInputError } from '@/utils/inputError';
-
-import { store } from './store';
+import { SignupForm } from './SignupForm';
 
 export default function Page() {
-  const { signUpResponse } = store.getSignUpResponse();
-
   return (
     <div className="space-y-4 md:w-80">
       <h1 className="text-2xl">Cadastre-se</h1>
@@ -22,65 +16,7 @@ export default function Page() {
         </Link>
       </p>
 
-      <form className="flex flex-col gap-3" action={store.signUpAction}>
-        <Input
-          required
-          id="name"
-          placeholder="Nome*"
-          name="name"
-          autoComplete="off"
-          error={setInputError('name', {
-            fields: signUpResponse?.error?.fields,
-            message: signUpResponse?.error?.message,
-          })}
-        />
-        <Input
-          required
-          id="email"
-          placeholder="Email*"
-          name="email"
-          error={setInputError('email', {
-            fields: signUpResponse?.error?.fields,
-            message: signUpResponse?.error?.message,
-          })}
-        />
-        <Input
-          required
-          id="userName"
-          placeholder="Username*"
-          name="userName"
-          autoComplete="off"
-          error={setInputError('userName', {
-            fields: signUpResponse?.error?.fields,
-            message: signUpResponse?.error?.message,
-          })}
-        />
-        <Input
-          required
-          id="password"
-          placeholder="Senha*"
-          type="password"
-          name="password"
-          autoComplete="off"
-          error={setInputError('password', {
-            fields: signUpResponse?.error?.fields,
-            message: signUpResponse?.error?.message,
-          })}
-        />
-        <Input
-          required
-          id="confirmPassword"
-          placeholder="Confirmar Senha*"
-          type="password"
-          name="confirmPassword"
-          autoComplete="off"
-          error={setInputError('confirmPassword', {
-            fields: signUpResponse?.error?.fields,
-            message: signUpResponse?.error?.message,
-          })}
-        />
-        <SubmitButton>Cadastrar</SubmitButton>
-      </form>
+      <SignupForm />
     </div>
   );
 }


### PR DESCRIPTION
## Done
- Refactored all the authentication form pages (signin, signup, forget-password, reset-password) to use `useActionState` react 19 hook.

Reference: https://react.dev/blog/2024/12/05/react-19#new-hook-useactionstate