### PR TITLE
Improves post page and dashboard, adding more information about it and the loading UI

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -8,7 +8,7 @@ import { verify } from '@/utils/verify';
 import type { Route } from 'next';
 
 export default async function Page() {
-  const { error: userNotAuthenticated } = await verify.loggedUser();
+  const { error: userNotAuthenticated, data: user } = await verify.loggedUser();
 
   const placeDataSource = createPlaceDataSource();
   const { data: places } = await place.findAll(placeDataSource, {
@@ -46,16 +46,21 @@ export default async function Page() {
           2xl:grid-cols-5
         `}
       >
-        {places?.map((place) => (
-          <ImageCard
-            href={`/dashboard/posts/${place.id}` as Route}
-            key={place.id}
-            title={place.name}
-            alt={`foto de ${place.name}`}
-            src={place.images[0] ?? 'https://via.placeholder.com/300'}
-            description={place.description ?? 'sem descrição'}
-          />
-        ))}
+        {places?.map((place) => {
+          const isPostOwner = place.created_by === user?.id;
+
+          return (
+            <ImageCard
+              href={`/dashboard/posts/${place.id}` as Route}
+              key={place.id}
+              title={place.name}
+              alt={`foto de ${place.name}`}
+              src={place.images[0] ?? 'https://via.placeholder.com/300'}
+              description={place.description ?? 'sem descrição'}
+              isOwner={isPostOwner}
+            />
+          );
+        })}
       </section>
     </div>
   );

--- a/app/dashboard/posts/[id]/loading.tsx
+++ b/app/dashboard/posts/[id]/loading.tsx
@@ -1,0 +1,27 @@
+import { Skeleton } from '@/components/ui/Skeleton';
+
+export default function Loading() {
+  return (
+    <div className="w-full space-y-6 pb-2 h-full">
+      <div className="w-full flex gap-2 items-center">
+        <h2 className="text-3xl">Foto(s) de</h2>
+        <Skeleton className="h-7 w-32 md:w-80 mt-1" />
+      </div>
+
+      <div className="flex flex-col md:flex-row px-4 gap-4 items-center md:items-baseline">
+        <Skeleton className="h-44 w-64 md:h-64 md:w-96 rounded-[20px]" />
+        <Skeleton className="h-44 w-64 md:h-64 md:w-96 rounded-[20px]" />
+      </div>
+
+      <div className="md:w-fit md:mx-auto space-y-4">
+        <h2 className="text-3xl md:text-center mb-2">Sobre o local:</h2>
+        <Skeleton className="h-4 w-52" />
+        <Skeleton className="h-4 w-52" />
+        <Skeleton className="h-4 w-52" />
+        <Skeleton className="h-4 w-52" />
+        <Skeleton className="h-4 w-52" />
+        <Skeleton className="h-4 w-52" />
+      </div>
+    </div>
+  );
+}

--- a/app/dashboard/posts/[id]/page.tsx
+++ b/app/dashboard/posts/[id]/page.tsx
@@ -1,7 +1,8 @@
 import { Button } from '@/components/ui/Button';
-import { createPlaceDataSource } from '@/data/place';
+import { type PlaceStatus, createPlaceDataSource } from '@/data/place';
 import { createUserDataSource } from '@/data/user';
 import { place } from '@/models/place';
+import { user } from '@/models/user';
 import { sanitizeClassName } from '@/utils/sanitizeClassName';
 import { verify } from '@/utils/verify';
 import Image from 'next/image';
@@ -43,9 +44,15 @@ export default async function Page(props: PageProps) {
   );
 
   const userDataSource = createUserDataSource();
-  const reviewedBy = await userDataSource.findById({
+
+  const { data: reviewedBy } = await user.findById(userDataSource, {
     id: postFound.reviewed_by!,
     select: ['name'],
+  });
+
+  const { data: postOwner } = await user.findById(userDataSource, {
+    id: postFound.created_by,
+    select: ['name', 'id'],
   });
 
   return (
@@ -110,7 +117,7 @@ export default async function Page(props: PageProps) {
 
         <TextInfo label="Categoria" value={postCategory?.name ?? '-'} />
 
-        <TextInfo label="Status" value={postFound.status} />
+        <PostStatus status={postFound.status} />
 
         {postFound.status !== 'PENDING' && (
           <TextInfo label="Revisado por" value={reviewedBy?.name ?? '-'} />
@@ -120,6 +127,8 @@ export default async function Page(props: PageProps) {
           label="Criado em"
           value={new Date(postFound.created_at).toLocaleDateString()}
         />
+
+        <TextInfo label="Criado por" value={postOwner?.name ?? '-'} />
 
         <TextInfo
           label="Atualizado em"
@@ -135,6 +144,27 @@ function TextInfo({ label, value }: { label: string; value: string }) {
     <div className="flex space-x-2">
       <span className="text-slate-500">{label}: </span>
       <span>{value}</span>
+    </div>
+  );
+}
+
+function PostStatus({ status }: { status: PlaceStatus }) {
+  const StatusEnum = {
+    PENDING: 'Pendente',
+    APPROVED: 'Aprovado',
+    REJECTED: 'Rejeitado',
+  };
+
+  const StatusStyleEnum = {
+    PENDING: 'text-yellow-500',
+    APPROVED: 'text-green-500',
+    REJECTED: 'text-red-500',
+  };
+
+  return (
+    <div className="flex space-x-2">
+      <span className="text-slate-500">Status: </span>
+      <span className={StatusStyleEnum[status]}>{StatusEnum[status]}</span>
     </div>
   );
 }

--- a/components/ImageCard.tsx
+++ b/components/ImageCard.tsx
@@ -28,7 +28,7 @@ export function ImageCard({
       title={title}
       href={href ?? '#'}
       className={sanitizeClassName(
-        'h-fit w-fit rounded-[20px] shadow',
+        'rounded-[20px] shadow w-[258px] md:w-[290px]',
         className,
       )}
     >

--- a/components/ImageCard.tsx
+++ b/components/ImageCard.tsx
@@ -1,7 +1,9 @@
 import Image from 'next/image';
 import Link from 'next/link';
 
+import { Badge } from '@/components/ui/Badge';
 import { sanitizeClassName } from '@/utils/sanitizeClassName';
+import { BadgeInfo } from 'lucide-react';
 import type { Route } from 'next';
 
 type ImageCardProps = {
@@ -12,6 +14,7 @@ type ImageCardProps = {
   variant?: 'md' | 'lg';
   className?: string;
   href?: Route;
+  isOwner?: boolean;
 };
 
 export function ImageCard({
@@ -22,13 +25,14 @@ export function ImageCard({
   variant = 'lg',
   src,
   href,
+  isOwner,
 }: ImageCardProps) {
   return (
     <Link
       title={title}
       href={href ?? '#'}
       className={sanitizeClassName(
-        'rounded-[20px] shadow w-[258px] md:w-[290px]',
+        'rounded-[20px] shadow w-[258px] md:w-[290px] relative',
         className,
       )}
     >
@@ -44,28 +48,29 @@ export function ImageCard({
             className="rounded-t-[20px] object-cover"
           />
         </div>
+
         <div
           className={sanitizeClassName(
             `
-          space-y-2
-          rounded-b-[20px]
-          bg-white
-          p-6
-          `,
+            space-y-2
+            rounded-b-[20px]
+            bg-white
+            p-6
+            `,
             variant === 'md' ? 'h-20' : 'h-28',
           )}
         >
           <h3
             className={`
-            max-w-56
-            overflow-hidden
-            text-ellipsis
-            whitespace-nowrap
-            text-xl
-            font-semibold
-            leading-5
-            text-[#123952]
-          `}
+              max-w-56
+              overflow-hidden
+              text-ellipsis
+              whitespace-nowrap
+              text-xl
+              font-semibold
+              leading-5
+              text-[#123952]
+            `}
           >
             {title}
           </h3>
@@ -77,12 +82,21 @@ export function ImageCard({
               whitespace-break-spaces
               leading-6
               text-muted-foreground
-          `}
+            `}
           >
             {description}
           </p>
         </div>
       </div>
+
+      {isOwner && (
+        <Badge
+          className="absolute top-2 right-2"
+          title="Você é o dono desse post"
+        >
+          <BadgeInfo />
+        </Badge>
+      )}
     </Link>
   );
 }

--- a/components/ui/Badge.tsx
+++ b/components/ui/Badge.tsx
@@ -1,0 +1,38 @@
+import { sanitizeClassName } from '@/utils/sanitizeClassName';
+import { type VariantProps, cva } from 'class-variance-authority';
+import type * as React from 'react';
+
+const badgeVariants = cva(
+  'inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  {
+    variants: {
+      variant: {
+        default:
+          'border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80',
+        secondary:
+          'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        destructive:
+          'border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80',
+        outline: 'text-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div
+      className={sanitizeClassName(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+export { Badge, badgeVariants };


### PR DESCRIPTION
## Done
- Created `loading.tsx` page to `/dashboard/posts/[id]` page, to render a `Skeleton` page while the `post` itself is being fetched
- Adjusted `ImageCard` component size
- Improved `/dashboard/post/[id]` page by adding `post owner` information
- Improved `/dashboard/post/[id]` page by styling each `post status` different
- Added `badge info` icon to show what posts the user is owner, in `/dashboard` page

## Preview
[Gravação de tela de 04-01-2025 17:46:16.webm](https://github.com/user-attachments/assets/6ea05c9b-5faf-4b1e-bb03-deab566053df)


