### PR TITLE
Creates `admin` Sidebar (CMS) to allow `pending` posts visualization

### DIFF
--- a/app/dashboard/_components/DashboardContent.tsx
+++ b/app/dashboard/_components/DashboardContent.tsx
@@ -49,7 +49,7 @@ export function DashboardContent({
   }
 
   return (
-    <div className="flex h-full flex-col gap-4">
+    <div className="flex h-full flex-col gap-4 w-full">
       <form className="px-6 flex flex-col md:flex-row gap-4 justify-center items-center md:justify-between">
         <fieldset className="flex gap-2 w-full justify-center md:justify-start items-center">
           <DebouncedInput
@@ -78,20 +78,22 @@ export function DashboardContent({
 
           {userId && (
             <Link
-              className={status === 'PENDING' ? 'pointer-events-none' : ''}
+              className={
+                status === 'user-pendings' ? 'pointer-events-none' : ''
+              }
               href={{
                 href: '/dashboard/',
                 query: {
-                  status: 'PENDING',
+                  status: 'user-pendings',
                 },
               }}
             >
               <Button
                 variant="secondary"
-                disabled={status === 'PENDING'}
+                disabled={status === 'user-pendings'}
                 className="text-xs md:text-base"
               >
-                Ver posts pendentes
+                Ver seus posts pendentes
               </Button>
             </Link>
           )}
@@ -100,7 +102,7 @@ export function DashboardContent({
 
       <PlacesFilters categories={categories} />
 
-      {status === 'PENDING' && (
+      {status === 'user-pendings' && (
         <Link className="w-fit self-end" href="/dashboard/" as="/dashboard/">
           <Button variant="link" className="text-xs md:text-base">
             Voltar para posts aprovados

--- a/app/dashboard/_components/PlacesFilters.tsx
+++ b/app/dashboard/_components/PlacesFilters.tsx
@@ -25,9 +25,7 @@ export function PlacesFilters({ categories }: PlacesFiltersProps) {
               },
             }}
             className={sanitizeClassName(
-              !currentFilter || currentFilter === 'all'
-                ? 'border-b-2 border-primary'
-                : '',
+              currentFilter === 'all' ? 'border-b-2 border-primary' : '',
             )}
           >
             Todos

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 
+import { CmsSidebar } from '@/components/CmsSidebar';
 import { Header } from '@/components/Header';
 import { verify } from '@/utils/verify';
 
@@ -14,8 +15,11 @@ export default async function Layout({ children }: Props) {
     <main className="flex h-screen flex-col overflow-y-hidden">
       <Header userData={data} />
 
-      <div className="mt-16 h-full px-1 py-10 lg:mt-10 lg:px-12">
-        {children}
+      <div className="flex h-full justify-between">
+        {data?.userRole === 'ADMIN' && <CmsSidebar />}
+        <div className="mt-16 h-full px-1 py-10 lg:mt-10 lg:px-12 flex w-full justify-center">
+          {children}
+        </div>
       </div>
     </main>
   );

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -6,7 +6,7 @@ import { DashboardContent } from './_components/DashboardContent';
 type Props = {
   searchParams: Promise<{
     type?: string;
-    status?: 'PENDING';
+    status?: 'user-pendings' | 'admin-pendings';
   }>;
 };
 
@@ -17,12 +17,20 @@ export default async function Page({ searchParams }: Props) {
 
   const userAuthenticated = !!user?.id;
   const userIsRequestingPendingPosts =
-    userAuthenticated && status === 'PENDING';
+    userAuthenticated && status === 'user-pendings';
+
+  const adminIsRequestingPendingPosts =
+    userAuthenticated &&
+    user.userRole === 'ADMIN' &&
+    status === 'admin-pendings';
 
   const placeDataSource = createPlaceDataSource();
   const { data: places } = await place.findAll(placeDataSource, {
     where: {
-      status: userIsRequestingPendingPosts ? 'PENDING' : 'APPROVED',
+      status:
+        userIsRequestingPendingPosts || adminIsRequestingPendingPosts
+          ? 'PENDING'
+          : 'APPROVED',
       categoryName: type === 'all' ? undefined : type,
       createdBy: userIsRequestingPendingPosts ? user.id : undefined,
     },

--- a/components/CmsSidebar.tsx
+++ b/components/CmsSidebar.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { sanitizeClassName } from '@/utils/sanitizeClassName';
+import { Check, ListTodo, MenuIcon } from 'lucide-react';
+import Link from 'next/link';
+import { type JSX, useEffect, useState } from 'react';
+import { Button } from './ui/Button';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from './ui/Sheet';
+
+export type CmsSidebarProps = JSX.IntrinsicElements['aside'];
+
+export function CmsSidebar({ className, ...props }: CmsSidebarProps) {
+  const [screenWidth, setScreenWidth] = useState(window.innerWidth);
+  const [isSheetOpen, setIsSheetOpen] = useState(false);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setScreenWidth(window.innerWidth);
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  function toggleSheetState() {
+    setIsSheetOpen((prevState) => !prevState);
+  }
+
+  const MOBILE_BREAKPOINT = 1200;
+  const isMobile = screenWidth < MOBILE_BREAKPOINT;
+
+  if (isMobile) {
+    return (
+      <div className="mt-16 p-4">
+        <Sheet open={isSheetOpen} onOpenChange={setIsSheetOpen}>
+          <SheetTrigger asChild>
+            <Button
+              variant="outline"
+              className="px-2"
+              onClick={() => setIsSheetOpen(true)}
+            >
+              <MenuIcon />
+            </Button>
+          </SheetTrigger>
+          <SheetContent side="left">
+            <SheetHeader className="space-y-8">
+              <SheetTitle>Gerenciamento de conteúdo</SheetTitle>
+              <SidebarItems />
+            </SheetHeader>
+          </SheetContent>
+        </Sheet>
+      </div>
+    );
+  }
+
+  return (
+    <aside
+      className={sanitizeClassName(
+        'border h-full p-4 text-muted-foreground space-y-8 text-center mt-16',
+        className,
+      )}
+      {...props}
+    >
+      <span>Gerenciamento de conteúdo</span>
+
+      <SidebarItems />
+    </aside>
+  );
+
+  function SidebarItems() {
+    return (
+      <ul className="text-secondary-foreground text-sm space-y-2">
+        <ListItem>
+          <Link
+            href={{
+              href: '/dashboard',
+              query: { status: 'admin-pendings' },
+            }}
+            className="flex gap-2 items-center flex-1 "
+          >
+            <ListTodo />
+            <span>Posts pendentes de aprovação</span>
+          </Link>
+        </ListItem>
+
+        <ListItem>
+          {/* TODO: Implement this */}
+          <Link
+            href="/dashboard/"
+            as="/dashboard/"
+            className="flex gap-2 items-center flex-1 "
+          >
+            <Check />
+            <span>Posts aprovados por você</span>
+          </Link>
+        </ListItem>
+      </ul>
+    );
+  }
+
+  function ListItem({ children }: { children: JSX.Element }) {
+    return (
+      <li>
+        <Button
+          onClick={isMobile ? toggleSheetState : undefined}
+          variant="ghost"
+          className="w-full justify-start"
+        >
+          {children}
+        </Button>
+      </li>
+    );
+  }
+}


### PR DESCRIPTION
## Done
- Created `CmsSidebar` component responsible to mobile and desktop screens
- Adjusted `Dashboard` layout to show the sidebar to admin users
- Adjusted `/dashboard` filters to allow filter pending posts by user id or only pending posts

## Preview

[Gravação de tela de 22-01-2025 22:07:04.webm](https://github.com/user-attachments/assets/f46bcf2d-92ec-4d82-94c6-1560c2ca9d5e)
