### PR TITLE
Creates pre-visualization modal for the `posts`

### DIFF
--- a/app/dashboard/_components/DashboardContent.tsx
+++ b/app/dashboard/_components/DashboardContent.tsx
@@ -190,11 +190,8 @@ export function DashboardContent({
               <ImageCard
                 href={`/dashboard/posts/${place.id}` as Route}
                 key={place.id}
-                title={place.name}
-                alt={`foto de ${place.name}`}
-                src={place.images[0] ?? 'https://via.placeholder.com/300'}
-                description={place.description ?? 'sem descrição'}
                 isOwner={isPostOwner}
+                place={place}
               />
             );
           })}

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -17,7 +17,7 @@ export default async function Layout({ children }: Props) {
 
       <div className="flex h-full justify-between">
         {data?.userRole === 'ADMIN' && <CmsSidebar />}
-        <div className="mt-10 h-full py-10 px-12 flex w-full justify-center">
+        <div className="mt-10 h-full p-10 flex w-full justify-center">
           {children}
         </div>
       </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { Header } from '@/components/Header';
 import { ImageCard } from '@/components/ImageCard';
 import { Button } from '@/components/ui/Button';
+import type { FindAllPlacesOutput } from '@/data/place';
 import { verify } from '@/utils/verify';
 
 export default async function Page() {
@@ -69,16 +70,12 @@ export default async function Page() {
         <section className="flex flex-col gap-8 py-4 lg:flex-row">
           <div className="flex flex-col gap-8 first:mt-10">
             {mockedData.firstColumn.map((place, index) => {
-              const description = `${place.country} - ${place.state}`;
-
               return (
                 <ImageCard
+                  clickable={false}
                   className="cursor-default"
                   key={`${index}-${place.name}`}
-                  title={place.name}
-                  description={description}
-                  alt={place.name}
-                  src={place.image_url}
+                  place={place}
                 />
               );
             })}
@@ -86,16 +83,12 @@ export default async function Page() {
 
           <div className="flex flex-col gap-8">
             {mockedData.secondColumn.map((place, index) => {
-              const description = `${place.country} - ${place.state}`;
-
               return (
                 <ImageCard
+                  clickable={false}
                   className="cursor-default"
                   key={`${index}-${place.name}`}
-                  title={place.name}
-                  description={description}
-                  alt={place.name}
-                  src={place.image_url}
+                  place={place}
                 />
               );
             })}
@@ -106,21 +99,39 @@ export default async function Page() {
   );
 }
 
-const mockedData = {
+const mockedData: Record<string, FindAllPlacesOutput[]> = {
   firstColumn: [
     {
       name: 'Café Bamboo',
       country: 'Brasil',
       state: 'ES',
-      image_url:
+      images: [
         'https://github.com/SouzaGabriel26/onde-ir/blob/main/assets/photo-restaurant-03.jpg?raw=true',
+      ],
+      category_id: '1',
+      city: 'Vitória',
+      created_at: new Date(),
+      created_by: '1',
+      id: '1',
+      status: 'APPROVED',
+      street: 'Rua das Flores',
+      updated_at: new Date(),
     },
     {
       name: 'Churrascaria Espeto de Ouro',
       country: 'Brasil',
       state: 'ES',
-      image_url:
+      images: [
         'https://github.com/SouzaGabriel26/onde-ir/blob/main/assets/photo-restaurant-01.jpg?raw=true',
+      ],
+      category_id: '1',
+      city: 'Vitória',
+      created_at: new Date(),
+      created_by: '1',
+      id: '2',
+      status: 'APPROVED',
+      street: 'Rua das Flores',
+      updated_at: new Date(),
     },
   ],
   secondColumn: [
@@ -128,15 +139,33 @@ const mockedData = {
       name: 'Restaurante do Porto',
       country: 'Brasil',
       state: 'ES',
-      image_url:
+      images: [
         'https://github.com/SouzaGabriel26/onde-ir/blob/main/assets/photo-restaurant-02.jpg?raw=true',
+      ],
+      category_id: '1',
+      city: 'Vitória',
+      created_at: new Date(),
+      created_by: '1',
+      id: '3',
+      status: 'APPROVED',
+      street: 'Rua das Flores',
+      updated_at: new Date(),
     },
     {
       name: 'Madero Steak House',
       country: 'Brasil',
       state: 'ES',
-      image_url:
+      images: [
         'https://github.com/SouzaGabriel26/onde-ir/blob/main/assets/photo-restaurant-05.jpg?raw=true',
+      ],
+      category_id: '1',
+      city: 'Vitória',
+      created_at: new Date(),
+      created_by: '1',
+      id: '4',
+      status: 'APPROVED',
+      street: 'Rua das Flores',
+      updated_at: new Date(),
     },
   ],
 };

--- a/components/ImageCard.tsx
+++ b/components/ImageCard.tsx
@@ -1,114 +1,172 @@
+'use client';
+
 import Image from 'next/image';
-import Link from 'next/link';
 
 import { CustomTooltip } from '@/components/CustomTooltip';
 import { Badge } from '@/components/ui/Badge';
+import type { FindAllPlacesOutput } from '@/data/place';
 import { sanitizeClassName } from '@/utils/sanitizeClassName';
-import { BadgeInfo } from 'lucide-react';
+import { BadgeInfo, MapPin, Star } from 'lucide-react';
 import type { Route } from 'next';
+import Link from 'next/link';
+import { useState } from 'react';
+import { Button } from './ui/Button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from './ui/Dialog';
 
 type ImageCardProps = {
-  src: string;
-  alt: string;
-  title: string;
-  description: string;
+  place: FindAllPlacesOutput;
   variant?: 'md' | 'lg';
   className?: string;
   href?: Route;
   isOwner?: boolean;
+  clickable?: boolean;
 };
 
 export function ImageCard({
   className,
-  alt,
-  title,
-  description,
+  place,
   variant = 'lg',
-  src,
   href,
   isOwner,
+  clickable = true,
 }: ImageCardProps) {
-  const MAX_DESCRIPTION_CHARACTERS = 51;
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   return (
-    <Link
-      href={href ?? '#'}
-      className={sanitizeClassName(
-        'rounded-[20px] shadow w-[258px] md:w-[290px] relative',
-        className,
-      )}
-    >
-      <CustomTooltip tip={title}>
-        <div className="rounded-[20px] border border-[#DCE2E5] transition hover:scale-105 hover:shadow-2xl">
-          <div
-            className={sanitizeClassName(
-              'relative',
-              'h-44 md:h-52 w-[258px] md:w-[290px]',
-            )}
-          >
+    <PostPreviewModal>
+      <div
+        className={sanitizeClassName(
+          'rounded-[20px] shadow w-[258px] md:w-[420px] relative',
+          className,
+        )}
+      >
+        <CustomTooltip tip={place.name}>
+          <div className="rounded-[20px] border border-[#DCE2E5] transition hover:scale-105 hover:shadow-2xl">
+            <div
+              className={sanitizeClassName(
+                'relative',
+                'h-44 md:h-52 w-[258px] md:w-[420px]',
+              )}
+            >
+              <Image
+                fill
+                src={place.images[0]}
+                alt={place.name}
+                sizes="100%"
+                className="rounded-t-[20px] object-cover"
+              />
+            </div>
+
+            <div
+              className={sanitizeClassName(
+                `
+                  w-[258px] md:w-[420px]
+                  space-y-2
+                  rounded-b-[20px]
+                  bg-white
+                  p-6
+                  md:flex
+                  md:justify-between
+                `,
+                variant === 'md' ? 'h-20' : 'h-28',
+              )}
+            >
+              <div>
+                <h3
+                  className={`
+                    overflow-hidden
+                    text-start
+                    text-ellipsis
+                    whitespace-nowrap
+                    text-base
+                    md:text-xl
+                    items-end
+                    font-semibold
+                    leading-5
+                    text-[#123952]
+                  `}
+                >
+                  {place.name}
+                </h3>
+                <p className="text-start text-muted-foreground text-sm md:text-sm flex gap-1 items-center">
+                  <MapPin className="size-4" />
+                  {place.city}, {place.state}
+                </p>
+              </div>
+
+              <div className="text-[#123952] flex items-center gap-1 self-end">
+                <Star fill="#123952" className="size-4" />
+                4.5
+              </div>
+            </div>
+          </div>
+        </CustomTooltip>
+
+        {isOwner && (
+          <Badge className="absolute top-2 right-2 rounded-full">
+            <CustomTooltip tip="Você é o dono desse post">
+              <BadgeInfo />
+            </CustomTooltip>
+          </Badge>
+        )}
+      </div>
+    </PostPreviewModal>
+  );
+
+  function PostPreviewModal({ children }: { children: React.ReactNode }) {
+    return (
+      <Dialog
+        open={clickable ? isModalOpen : false}
+        onOpenChange={setIsModalOpen}
+      >
+        <DialogTrigger asChild>{children}</DialogTrigger>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{place.name}</DialogTitle>
+          </DialogHeader>
+
+          <div className="relative h-64">
             <Image
+              src={place.images[0]}
+              alt={place.name}
               fill
-              src={src}
-              alt={alt}
-              sizes="100%"
-              className="rounded-t-[20px] object-cover"
+              objectFit="cover"
             />
           </div>
 
-          <div
-            className={sanitizeClassName(
-              `
-              w-[258px] md:w-[290px]
-              space-y-2
-              rounded-b-[20px]
-              bg-white
-              p-6
-            `,
-              variant === 'md' ? 'h-20' : 'h-28',
-            )}
-          >
-            <h3
-              className={`
-                max-w-56
-                overflow-hidden
-                text-ellipsis
-                whitespace-nowrap
-                text-base
-                md:text-xl
-                font-semibold
-                leading-5
-                text-[#123952]
-              `}
-            >
-              {title}
-            </h3>
-            <p
-              className={`
-                max-w-56
-                overflow-hidden
-                break-words
-                leading-6
-                text-muted-foreground
-                text-xs
-                sm:text-sm
-                md:text-base
-              `}
-            >
-              {description.length > MAX_DESCRIPTION_CHARACTERS
-                ? description.slice(0, MAX_DESCRIPTION_CHARACTERS).concat('...')
-                : description}
-            </p>
-          </div>
-        </div>
-      </CustomTooltip>
+          <div className="flex justify-between gap-4 p-6">
+            <div className="space-y-2">
+              <p className="text-muted-foreground flex items-center gap-1 text-sm">
+                <MapPin className="size-4" />
+                {place.city}, {place.state}
+              </p>
 
-      {isOwner && (
-        <Badge className="absolute top-2 right-2 rounded-full">
-          <CustomTooltip tip="Você é o dono desse post">
-            <BadgeInfo />
-          </CustomTooltip>
-        </Badge>
-      )}
-    </Link>
-  );
+              <p className="text-sm text-muted-foreground">{place.street}</p>
+            </div>
+
+            <div className="flex gap-2 items-center text-primary self-start">
+              <Star className="size-4 fill-primary" />
+              <Star className="size-4 fill-primary" />
+              <Star className="size-4 fill-primary" />
+              <Star className="size-4 fill-primary" />
+              <Star className="size-4" />
+              4.5
+            </div>
+          </div>
+
+          <p className="text-sm text-center">{place.description}</p>
+
+          <Link href={href ?? '#'} className="w-full">
+            <Button className="w-full">Ver mais detalhes</Button>
+          </Link>
+        </DialogContent>
+      </Dialog>
+    );
+  }
 }

--- a/components/ui/Dialog.tsx
+++ b/components/ui/Dialog.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { sanitizeClassName } from '@/utils/sanitizeClassName';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+import * as React from 'react';
+
+const Dialog = DialogPrimitive.Root;
+
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={sanitizeClassName(
+      'fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className,
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={sanitizeClassName(
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={sanitizeClassName(
+      'flex flex-col space-y-1.5 text-center sm:text-left',
+      className,
+    )}
+    {...props}
+  />
+);
+DialogHeader.displayName = 'DialogHeader';
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={sanitizeClassName(
+      'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+      className,
+    )}
+    {...props}
+  />
+);
+DialogFooter.displayName = 'DialogFooter';
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={sanitizeClassName(
+      'text-lg font-semibold leading-none tracking-tight',
+      className,
+    )}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={sanitizeClassName('text-sm text-muted-foreground', className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+};


### PR DESCRIPTION
## Done
- Created `Dialog` component using shadcn
- Added a preview modal for the post, before redirect the user to `/post/:id` page
- Adjusted `/` page mocked data to follow `FindAllPlacesOutput` type
- Adjusted `/dashboard` to the new type of `ImageCard` component

## Preview
[Gravação de tela de 10-02-2025 19:32:43.webm](https://github.com/user-attachments/assets/80b0ff72-170f-4236-a2f1-8f6eab96c966)
