### PR TITLE
Integrates `post preview modal` with a carousel library

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -22,6 +22,7 @@
     "rules": {
       "recommended": true,
       "a11y": {
+        "useKeyWithClickEvents": "off",
         "noSvgWithoutTitle": "off",
         "useButtonType": "off"
       },

--- a/components/Carousel.tsx
+++ b/components/Carousel.tsx
@@ -1,0 +1,260 @@
+'use client';
+
+import { sanitizeClassName } from '@/utils/sanitizeClassName';
+import useEmblaCarousel, {
+  type UseEmblaCarouselType,
+} from 'embla-carousel-react';
+import { ArrowLeft, ArrowRight } from 'lucide-react';
+import * as React from 'react';
+import { Button } from './ui/Button';
+
+type CarouselApi = UseEmblaCarouselType[1];
+type UseCarouselParameters = Parameters<typeof useEmblaCarousel>;
+type CarouselOptions = UseCarouselParameters[0];
+type CarouselPlugin = UseCarouselParameters[1];
+
+type CarouselProps = {
+  opts?: CarouselOptions;
+  plugins?: CarouselPlugin;
+  orientation?: 'horizontal' | 'vertical';
+  setApi?: (api: CarouselApi) => void;
+};
+
+type CarouselContextProps = {
+  carouselRef: ReturnType<typeof useEmblaCarousel>[0];
+  api: ReturnType<typeof useEmblaCarousel>[1];
+  scrollPrev: () => void;
+  scrollNext: () => void;
+  canScrollPrev: boolean;
+  canScrollNext: boolean;
+} & CarouselProps;
+
+const CarouselContext = React.createContext<CarouselContextProps | null>(null);
+
+function useCarousel() {
+  const context = React.useContext(CarouselContext);
+
+  if (!context) {
+    throw new Error('useCarousel must be used within a <Carousel />');
+  }
+
+  return context;
+}
+
+const Carousel = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & CarouselProps
+>(
+  (
+    {
+      orientation = 'horizontal',
+      opts,
+      setApi,
+      plugins,
+      className,
+      children,
+      ...props
+    },
+    ref,
+  ) => {
+    const [carouselRef, api] = useEmblaCarousel(
+      {
+        ...opts,
+        axis: orientation === 'horizontal' ? 'x' : 'y',
+      },
+      plugins,
+    );
+    const [canScrollPrev, setCanScrollPrev] = React.useState(false);
+    const [canScrollNext, setCanScrollNext] = React.useState(false);
+
+    const onSelect = React.useCallback((api: CarouselApi) => {
+      if (!api) {
+        return;
+      }
+
+      setCanScrollPrev(api.canScrollPrev());
+      setCanScrollNext(api.canScrollNext());
+    }, []);
+
+    const scrollPrev = React.useCallback(() => {
+      api?.scrollPrev();
+    }, [api]);
+
+    const scrollNext = React.useCallback(() => {
+      api?.scrollNext();
+    }, [api]);
+
+    const handleKeyDown = React.useCallback(
+      (event: React.KeyboardEvent<HTMLDivElement>) => {
+        if (event.key === 'ArrowLeft') {
+          event.preventDefault();
+          scrollPrev();
+        } else if (event.key === 'ArrowRight') {
+          event.preventDefault();
+          scrollNext();
+        }
+      },
+      [scrollPrev, scrollNext],
+    );
+
+    React.useEffect(() => {
+      if (!api || !setApi) {
+        return;
+      }
+
+      setApi(api);
+    }, [api, setApi]);
+
+    React.useEffect(() => {
+      if (!api) {
+        return;
+      }
+
+      onSelect(api);
+      api.on('reInit', onSelect);
+      api.on('select', onSelect);
+
+      return () => {
+        api?.off('select', onSelect);
+      };
+    }, [api, onSelect]);
+
+    return (
+      <CarouselContext.Provider
+        value={{
+          carouselRef,
+          api: api,
+          opts,
+          orientation:
+            orientation || (opts?.axis === 'y' ? 'vertical' : 'horizontal'),
+          scrollPrev,
+          scrollNext,
+          canScrollPrev,
+          canScrollNext,
+        }}
+      >
+        <div
+          ref={ref}
+          onKeyDownCapture={handleKeyDown}
+          className={sanitizeClassName('relative', className)}
+          aria-roledescription="carousel"
+          {...props}
+        >
+          {children}
+        </div>
+      </CarouselContext.Provider>
+    );
+  },
+);
+Carousel.displayName = 'Carousel';
+
+const CarouselContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const { carouselRef, orientation } = useCarousel();
+
+  return (
+    <div ref={carouselRef} className="overflow-hidden">
+      <div
+        ref={ref}
+        className={sanitizeClassName(
+          'flex',
+          orientation === 'horizontal' ? '-ml-4' : '-mt-4 flex-col',
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  );
+});
+CarouselContent.displayName = 'CarouselContent';
+
+const CarouselItem = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const { orientation } = useCarousel();
+
+  return (
+    <div
+      ref={ref}
+      role="group"
+      aria-roledescription="slide"
+      className={sanitizeClassName(
+        'min-w-0 shrink-0 grow-0 basis-full',
+        orientation === 'horizontal' ? 'pl-4' : 'pt-4',
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+CarouselItem.displayName = 'CarouselItem';
+
+const CarouselPrevious = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<typeof Button>
+>(({ className, variant = 'outline', size = 'icon', ...props }, ref) => {
+  const { orientation, scrollPrev, canScrollPrev } = useCarousel();
+
+  return (
+    <Button
+      ref={ref}
+      variant={variant}
+      size={size}
+      className={sanitizeClassName(
+        'absolute  h-8 w-8 rounded-full',
+        orientation === 'horizontal'
+          ? '-left-12 top-1/2 -translate-y-1/2'
+          : '-top-12 left-1/2 -translate-x-1/2 rotate-90',
+        className,
+      )}
+      disabled={!canScrollPrev}
+      onClick={scrollPrev}
+      {...props}
+    >
+      <ArrowLeft className="h-4 w-4" />
+      <span className="sr-only">Previous slide</span>
+    </Button>
+  );
+});
+CarouselPrevious.displayName = 'CarouselPrevious';
+
+const CarouselNext = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<typeof Button>
+>(({ className, variant = 'outline', size = 'icon', ...props }, ref) => {
+  const { orientation, scrollNext, canScrollNext } = useCarousel();
+
+  return (
+    <Button
+      ref={ref}
+      variant={variant}
+      size={size}
+      className={sanitizeClassName(
+        'absolute h-8 w-8 rounded-full',
+        orientation === 'horizontal'
+          ? '-right-12 top-1/2 -translate-y-1/2'
+          : '-bottom-12 left-1/2 -translate-x-1/2 rotate-90',
+        className,
+      )}
+      disabled={!canScrollNext}
+      onClick={scrollNext}
+      {...props}
+    >
+      <ArrowRight className="h-4 w-4" />
+      <span className="sr-only">Next slide</span>
+    </Button>
+  );
+});
+CarouselNext.displayName = 'CarouselNext';
+
+export {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+  type CarouselApi,
+};

--- a/components/ImageCard.tsx
+++ b/components/ImageCard.tsx
@@ -8,16 +8,9 @@ import type { FindAllPlacesOutput } from '@/data/place';
 import { sanitizeClassName } from '@/utils/sanitizeClassName';
 import { BadgeInfo, MapPin, Star } from 'lucide-react';
 import type { Route } from 'next';
-import Link from 'next/link';
 import { useState } from 'react';
-import { Button } from './ui/Button';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from './ui/Dialog';
+
+import { PostPreviewModal } from './PostPreviewModal';
 
 type ImageCardProps = {
   place: FindAllPlacesOutput;
@@ -39,8 +32,9 @@ export function ImageCard({
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   return (
-    <PostPreviewModal>
+    <>
       <div
+        onClick={() => clickable && setIsModalOpen(true)}
         className={sanitizeClassName(
           'rounded-[20px] shadow w-[258px] md:w-[420px] relative',
           className,
@@ -116,57 +110,12 @@ export function ImageCard({
           </Badge>
         )}
       </div>
-    </PostPreviewModal>
+      <PostPreviewModal
+        place={place}
+        href={href ?? '#'}
+        setIsOpen={setIsModalOpen}
+        isOpen={isModalOpen}
+      />
+    </>
   );
-
-  function PostPreviewModal({ children }: { children: React.ReactNode }) {
-    return (
-      <Dialog
-        open={clickable ? isModalOpen : false}
-        onOpenChange={setIsModalOpen}
-      >
-        <DialogTrigger asChild>{children}</DialogTrigger>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>{place.name}</DialogTitle>
-          </DialogHeader>
-
-          <div className="relative h-64">
-            <Image
-              src={place.images[0]}
-              alt={place.name}
-              fill
-              objectFit="cover"
-            />
-          </div>
-
-          <div className="flex justify-between gap-4 p-6">
-            <div className="space-y-2">
-              <p className="text-muted-foreground flex items-center gap-1 text-sm">
-                <MapPin className="size-4" />
-                {place.city}, {place.state}
-              </p>
-
-              <p className="text-sm text-muted-foreground">{place.street}</p>
-            </div>
-
-            <div className="flex gap-2 items-center text-primary self-start">
-              <Star className="size-4 fill-primary" />
-              <Star className="size-4 fill-primary" />
-              <Star className="size-4 fill-primary" />
-              <Star className="size-4 fill-primary" />
-              <Star className="size-4" />
-              4.5
-            </div>
-          </div>
-
-          <p className="text-sm text-center">{place.description}</p>
-
-          <Link href={href ?? '#'} className="w-full">
-            <Button className="w-full">Ver mais detalhes</Button>
-          </Link>
-        </DialogContent>
-      </Dialog>
-    );
-  }
 }

--- a/components/PostPreviewModal.tsx
+++ b/components/PostPreviewModal.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import type { FindAllPlacesOutput } from '@/data/place';
+import { MapPin, Star } from 'lucide-react';
+import Image from 'next/image';
+import Link from 'next/link';
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from './Carousel';
+import { Button } from './ui/Button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from './ui/Dialog';
+
+type PostPreviewModalProps = {
+  place: FindAllPlacesOutput;
+  isOpen: boolean;
+  href: string;
+  setIsOpen: (isOpen: boolean) => void;
+};
+
+export function PostPreviewModal({
+  isOpen,
+  place,
+  href,
+  setIsOpen,
+}: PostPreviewModalProps) {
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{place.name}</DialogTitle>
+        </DialogHeader>
+
+        <DialogDescription>{place.description}</DialogDescription>
+
+        <div className="flex justify-center px-8 md:px-0">
+          <Carousel className="w-full max-w-xs">
+            <CarouselContent>
+              {place.images.map((placeImage) => (
+                <CarouselItem key={placeImage}>
+                  <div className="relative h-64">
+                    <Image
+                      src={placeImage}
+                      alt={place.name}
+                      fill
+                      objectFit="cover"
+                    />
+                  </div>
+                </CarouselItem>
+              ))}
+            </CarouselContent>
+            <CarouselPrevious />
+            <CarouselNext />
+          </Carousel>
+        </div>
+
+        <p className="text-end text-muted-foreground">
+          {place.images.length > 1
+            ? `${place.images.length} fotos`
+            : `${place.images.length} foto`}
+        </p>
+
+        <div className="flex justify-between gap-4 p-6">
+          <div className="space-y-2">
+            <p className="text-muted-foreground flex items-center gap-1 text-sm">
+              <MapPin className="size-4" />
+              {place.city}, {place.state}
+            </p>
+
+            <p className="text-sm text-muted-foreground">{place.street}</p>
+          </div>
+
+          <div className="flex gap-2 items-center text-primary self-start">
+            <Star className="size-4 fill-primary" />
+            <Star className="size-4 fill-primary" />
+            <Star className="size-4 fill-primary" />
+            <Star className="size-4 fill-primary" />
+            <Star className="size-4" />
+            4.5
+          </div>
+        </div>
+
+        <Link href={href ?? '#'} className="w-full">
+          <Button className="w-full">Ver mais detalhes</Button>
+        </Link>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/infra/queries/06-populate-places-images-table.sql
+++ b/infra/queries/06-populate-places-images-table.sql
@@ -106,6 +106,11 @@ VALUES
     'Foto de pastéis crocantes'
 ),
 (
+    (SELECT id FROM places WHERE name = 'Pizzaria do Zé'),
+    'https://plus.unsplash.com/premium_photo-1671394138398-fe1ce5e5b03b?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+    'Foto de pastéis crocantes'
+),
+(
     (SELECT id FROM places WHERE name = 'Espetaria Sabor do Churrasco'),
     'https://images.unsplash.com/photo-1555396273-367ea4eb4db5?q=80&w=1974&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
     'Foto dos espetinhos no carvão'

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@react-email/components": "^0.0.25",
     "axios": "^1.7.9",
     "class-variance-authority": "^0.7.0",
+    "embla-carousel-react": "^8.5.2",
     "framer-motion": "^11.9.0",
     "jose": "^5.9.3",
     "next": "15.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.0
+      embla-carousel-react:
+        specifier: ^8.5.2
+        version: 8.5.2(react@19.0.0)
       framer-motion:
         specifier: ^11.9.0
         version: 11.9.0(@emotion/is-prop-valid@0.8.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -2119,6 +2122,19 @@ packages:
     resolution: {integrity: sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==}
     engines: {node: '>=14'}
     hasBin: true
+
+  embla-carousel-react@8.5.2:
+    resolution: {integrity: sha512-Tmx+uY3MqseIGdwp0ScyUuxpBgx5jX1f7od4Cm5mDwg/dptEiTKf9xp6tw0lZN2VA9JbnVMl/aikmbc53c6QFA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+
+  embla-carousel-reactive-utils@8.5.2:
+    resolution: {integrity: sha512-QC8/hYSK/pEmqEdU1IO5O+XNc/Ptmmq7uCB44vKplgLKhB/l0+yvYx0+Cv0sF6Ena8Srld5vUErZkT+yTahtDg==}
+    peerDependencies:
+      embla-carousel: 8.5.2
+
+  embla-carousel@8.5.2:
+    resolution: {integrity: sha512-xQ9oVLrun/eCG/7ru3R+I5bJ7shsD8fFwLEY7yPe27/+fDHCNj0OT5EoG5ZbFyOxOcG6yTwW8oTz/dWyFnyGpg==}
 
   emoji-regex@10.3.0:
     resolution: {integrity: sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==}
@@ -5835,6 +5851,18 @@ snapshots:
       commander: 10.0.1
       minimatch: 9.0.1
       semver: 7.6.2
+
+  embla-carousel-react@8.5.2(react@19.0.0):
+    dependencies:
+      embla-carousel: 8.5.2
+      embla-carousel-reactive-utils: 8.5.2(embla-carousel@8.5.2)
+      react: 19.0.0
+
+  embla-carousel-reactive-utils@8.5.2(embla-carousel@8.5.2):
+    dependencies:
+      embla-carousel: 8.5.2
+
+  embla-carousel@8.5.2: {}
 
   emoji-regex@10.3.0: {}
 

--- a/tests/models/place.test.ts
+++ b/tests/models/place.test.ts
@@ -174,7 +174,7 @@ describe('> models/place', () => {
             created_by: expect.any(String),
             created_at: expect.any(Date),
             updated_at: expect.any(Date),
-            images: [],
+            images: expect.any(Array),
           },
         ],
       });
@@ -529,7 +529,7 @@ describe('> models/place', () => {
         SELECT * FROM place_images
       `);
 
-      expect(placeImagesBefore?.rows.length).toBe(21);
+      expect(placeImagesBefore?.rows.length).toBe(22);
 
       const placeDataSource = createPlaceDataSource();
       const places = await place.findAll(placeDataSource, { limit: 1 });
@@ -549,7 +549,7 @@ describe('> models/place', () => {
         SELECT * FROM place_images
       `);
 
-      expect(placeImagesAfter?.rows.length).toBe(23);
+      expect(placeImagesAfter?.rows.length).toBe(24);
     });
   });
 


### PR DESCRIPTION
## Done
- Created a `Carousel` component with shadcn and embla-carousel-react
- Created `PostPreviewModal` component using `Carousel`
- Integrated `PostPreviewModal` with `ImageCard` component
- Added mocked image to populate a place in SQL seed script

## Preview

[Gravação de tela de 13-02-2025 18:34:51.webm](https://github.com/user-attachments/assets/644a7d40-ef58-4444-9264-39fd0c6d39b3)
