### PR TITLE
[Back/Front]: Implements functionality of `edit comment`

### DIFF
--- a/app/dashboard/posts/[id]/_components/PlaceComments.tsx
+++ b/app/dashboard/posts/[id]/_components/PlaceComments.tsx
@@ -39,7 +39,7 @@ export function PlaceComments({
         />
 
         <Button disabled={!userId || isPending} className="self-end">
-          {isPending ? 'Publicar comentário' : 'Publicando comentário...'}
+          {isPending ? 'Publicando comentário...' : 'Publicar comentário'}
         </Button>
 
         <input type="hidden" name="userId" value={userId} />

--- a/app/dashboard/posts/[id]/actions.ts
+++ b/app/dashboard/posts/[id]/actions.ts
@@ -6,6 +6,7 @@ import {
   type UpdateInput as ApprovePlaceInput,
   type CreateCommentInput,
   type DeleteCommentInput,
+  type UpdateCommentInput,
   place,
 } from '@/models/place';
 import { feedbackMessage } from '@/utils/feedbackMessage';
@@ -118,5 +119,34 @@ export async function deleteCommentAction(
   return await feedbackMessage.setFeedbackMessage({
     type: 'success',
     content: 'Comentário removido com sucesso!',
+  });
+}
+
+export async function updateCommentAction(
+  _prevState: unknown,
+  formData: FormData,
+) {
+  const { commentId, description, userId } =
+    form.sanitizeData<UpdateCommentInput>(formData);
+
+  const userDataSource = createUserDataSource();
+  const placeDataSource = createPlaceDataSource();
+
+  const result = await place.updateComment(userDataSource, placeDataSource, {
+    commentId,
+    description,
+    userId,
+  });
+
+  if (result.error) {
+    return await feedbackMessage.setFeedbackMessage({
+      type: 'error',
+      content: result.error.message,
+    });
+  }
+
+  return await feedbackMessage.setFeedbackMessage({
+    type: 'success',
+    content: 'Comentário atualizado com sucesso!',
   });
 }

--- a/data/place.ts
+++ b/data/place.ts
@@ -74,6 +74,7 @@ export function createPlaceDataSource() {
     checkCommentById,
     deleteComment,
     getCommentOwner,
+    updateComment,
   });
 
   type FindAllInput = {
@@ -478,5 +479,26 @@ export function createPlaceDataSource() {
       text: query,
       values: [input.commentId],
     });
+  }
+
+  type UpdateCommentInput = {
+    commentId: string;
+    description: string;
+  };
+
+  async function updateComment(input: UpdateCommentInput) {
+    const query = {
+      text: sql`
+        UPDATE place_comments
+        SET
+          description = $1,
+          updated_at = NOW() AT TIME ZONE 'UTC'
+        WHERE
+          id = $2;
+      `,
+      values: [input.description, input.commentId],
+    };
+
+    await placePool.query(query);
   }
 }

--- a/tests/models/place.test.ts
+++ b/tests/models/place.test.ts
@@ -1174,6 +1174,57 @@ describe('> models/place', () => {
       expect(commentsAfterDelete.data).toHaveLength(1);
     });
   });
+
+  describe('Invoking "updateComment" method', () => {
+    test('Providing valid inputs', async () => {
+      const userDataSource = createUserDataSource();
+      const placeDataSource = createPlaceDataSource();
+
+      const { data: placeWithComments } = await place.findAll(placeDataSource, {
+        where: {
+          name: 'Churrascaria Espeto de Ouro',
+        },
+      });
+
+      const placeId = placeWithComments![0].id;
+
+      const { data: comments } = await place.findComments(
+        placeDataSource,
+        placeId,
+      );
+
+      expect(comments![0].description).toBe(
+        'Achei interessante este local, frequento bastante!',
+      );
+
+      const result = await place.updateComment(
+        userDataSource,
+        placeDataSource,
+        {
+          userId: comments![0].user_id,
+          commentId: comments![0].id,
+          description: 'Updated comment',
+        },
+      );
+      await placeDataSource.deleteComment({
+        commentId: comments![1].id,
+        placeId: comments![1].place_id,
+        userId: comments![1].user_id,
+      });
+
+      expect(result).toStrictEqual({
+        data: {},
+        error: null,
+      });
+
+      const { data: commentsAfterUpdate } = await place.findComments(
+        placeDataSource,
+        placeId,
+      );
+
+      expect(commentsAfterUpdate![0].description).toBe('Updated comment');
+    });
+  });
 });
 
 async function getUserId() {

--- a/tests/models/place.test.ts
+++ b/tests/models/place.test.ts
@@ -1177,6 +1177,8 @@ describe('> models/place', () => {
 
   describe('Invoking "updateComment" method', () => {
     test('Providing valid inputs', async () => {
+      await orchestrator.resetDatabase();
+
       const userDataSource = createUserDataSource();
       const placeDataSource = createPlaceDataSource();
 


### PR DESCRIPTION
## Done
- Created `updateComment` method in both model and datasource
- Created test to `updateComment` method
- Adjusted `register comment` button text
- Integrated `updateComment` method with frontend using `server actions` and `useActionState` hook 

## Preview
[Gravação de tela de 27-02-2025 10:44:08.webm](https://github.com/user-attachments/assets/123b6654-4d51-4173-b60a-62fca405eaac)
