### PR TITLE
Adjusts loading skeleton in `/dashboard/posts/:id` page

### DIFF
--- a/app/dashboard/posts/[id]/loading.tsx
+++ b/app/dashboard/posts/[id]/loading.tsx
@@ -8,19 +8,21 @@ export default function Loading() {
         <Skeleton className="h-7 w-32 md:w-80 mt-1" />
       </div>
 
-      <div className="flex flex-col md:flex-row px-4 gap-4 items-center md:items-baseline">
-        <Skeleton className="h-44 w-64 md:h-64 md:w-96 rounded-[20px]" />
-        <Skeleton className="h-44 w-64 md:h-64 md:w-96 rounded-[20px]" />
+      <div className="px-4 gap-4 items-center md:items-baseline flex justify-center">
+        <Skeleton className="h-[300px] w-[300px] md:h-[600px] md:w-[1300px] rounded-[20px]" />
       </div>
 
       <div className="md:w-fit md:mx-auto space-y-4">
         <h2 className="text-3xl md:text-center mb-2">Sobre o local:</h2>
-        <Skeleton className="h-4 w-52" />
-        <Skeleton className="h-4 w-52" />
-        <Skeleton className="h-4 w-52" />
-        <Skeleton className="h-4 w-52" />
-        <Skeleton className="h-4 w-52" />
-        <Skeleton className="h-4 w-52" />
+
+        <div className="grid grid-cols-1 place-items-center md:grid-cols-3 gap-4">
+          <Skeleton className="h-4 w-52" />
+          <Skeleton className="h-4 w-52" />
+          <Skeleton className="h-4 w-52" />
+          <Skeleton className="h-4 w-52" />
+          <Skeleton className="h-4 w-52" />
+          <Skeleton className="h-4 w-52" />
+        </div>
       </div>
     </div>
   );

--- a/components/PostPreviewModal.tsx
+++ b/components/PostPreviewModal.tsx
@@ -90,7 +90,7 @@ export function PostPreviewModal({
           </div>
         </div>
 
-        <Link href={href ?? '#'} className="w-full">
+        <Link href={href ?? '#'} prefetch className="w-full">
           <Button className="w-full">Ver mais detalhes</Button>
         </Link>
       </DialogContent>


### PR DESCRIPTION
## Done
- Added `prefetch` option to the `Link` tag in `PostPreviewModal` component
- Adjusted `skeleton` layout in `/dashboard/posts/:id/loading.tsx`

## Preview
[Gravação de tela de 01-03-2025 16:27:50.webm](https://github.com/user-attachments/assets/24fd22e8-dab0-45f2-95d5-894e0a31c134)
