### PR TITLE
Fix/create post env error

### DIFF
--- a/app/actions/getPresignedURL.ts
+++ b/app/actions/getPresignedURL.ts
@@ -1,0 +1,20 @@
+'use server';
+
+import { env } from '@/utils/env';
+import axios from 'axios';
+
+type GetPresignedURLResponse = {
+  presigned_url: string;
+  file_url: string;
+};
+
+export async function getPresignedURL(file: File) {
+  const { data } = await axios.post<GetPresignedURLResponse>(
+    env.LAMBDA_FUNCTION_URL,
+    {
+      fileName: file.name,
+    },
+  );
+
+  return data;
+}

--- a/app/auth/signup/SignupForm.tsx
+++ b/app/auth/signup/SignupForm.tsx
@@ -89,7 +89,7 @@ export function SignupForm() {
         type="file"
         accept="image/png, image/jpg, image/jpeg"
         name="avatar_file"
-        className="cursor-pointer hover:bg-primary-foreground transition-all"
+        className="cursor-pointer hover:bg-muted transition-all"
       />
 
       <SubmitButton>Cadastrar</SubmitButton>

--- a/app/auth/signup/store.ts
+++ b/app/auth/signup/store.ts
@@ -2,9 +2,10 @@
 
 import { redirect } from 'next/navigation';
 
+import { getPresignedURL } from '@/app/actions/getPresignedURL';
 import { Welcome } from '@/components/email-templates/Welcome';
 import { createAuthenticationDataSource } from '@/data/authentication';
-import { getPresignedURL, uploadFileToS3 } from '@/data/lambda';
+import { uploadFileToS3 } from '@/data/lambda';
 import {
   type SignUpProps,
   type SignUpResponse,

--- a/app/dashboard/_components/DashboardContent.tsx
+++ b/app/dashboard/_components/DashboardContent.tsx
@@ -185,10 +185,11 @@ export function DashboardContent({
             rounded-[20px]
             gap-10
             overflow-y-auto
-            scroolbar
+            scrollbar
             pb-16
             px-4
             pt-4
+            justify-items-center
             items-center
           `}
         >

--- a/app/dashboard/posts/[id]/_components/PlaceComments.tsx
+++ b/app/dashboard/posts/[id]/_components/PlaceComments.tsx
@@ -62,7 +62,7 @@ export function PlaceComments({
               />
 
               {hasChildComments && (
-                <div className="ml-10 md:ml-24 border-l my-2 max-h-48 overflow-y-auto scroolbar divide-y">
+                <div className="ml-10 md:ml-24 border-l my-2 max-h-48 overflow-y-auto scrollbar divide-y">
                   {comment.child_comments?.map((childComment) => (
                     <PlaceComment
                       key={childComment.id}

--- a/app/dashboard/posts/[id]/page.tsx
+++ b/app/dashboard/posts/[id]/page.tsx
@@ -62,14 +62,14 @@ export default async function Page(props: PageProps) {
   );
 
   return (
-    <div className="w-full space-y-6 pb-2">
+    <div className="w-full space-y-6 pb-10">
       {loggedUser && !userAlreadyEvaluated && (
         <RatingModal
           key={Date.now()}
           placeId={postId}
           userId={loggedUser?.id ?? ''}
           action={ratePlaceAction}
-          className="top-0 right-2 absolute"
+          className="top-2 right-2 absolute"
         />
       )}
 
@@ -136,7 +136,7 @@ export default async function Page(props: PageProps) {
                     src={url}
                     alt={`Foto ${index + 1} de ${postFound.name}`}
                     sizes="100%"
-                    className="rounded-[20px] object-cover"
+                    className="rounded-[20px] object-contain"
                   />
 
                   <Badge

--- a/app/dashboard/posts/_components/ImageUpload.tsx
+++ b/app/dashboard/posts/_components/ImageUpload.tsx
@@ -23,14 +23,17 @@ type ImageUploadProps = {
   successRedirectPath?: string;
 };
 
+const MAX_FILES = 5;
+
 export function ImageUpload({
   actionOnUpload,
   successRedirectPath,
 }: ImageUploadProps) {
   const route = useRouter();
 
-  const [isLoading, setIsLoading] = useState(false);
+  const [isUploadingFiles, setIsUploadingFiles] = useState(false);
   const [uploads, setUploads] = useState<Array<Upload>>([]);
+  const [isDropping, setIsDropping] = useState(false);
 
   const hasSomeInvalidFileType = useMemo(() => {
     return uploads.some(
@@ -38,8 +41,27 @@ export function ImageUpload({
     );
   }, [uploads]);
 
-  const onDrop = useCallback((acceptedFiles: Array<File>) => {
-    setUploads(acceptedFiles.map((file) => ({ file, progress: 0 })));
+  const onDrop = useCallback(async (acceptedFiles: Array<File>) => {
+    setIsDropping(true);
+
+    setUploads((prevUploads) => {
+      const uploadsToAdd = acceptedFiles.filter((file) => {
+        const isFileAlreadyAdded = prevUploads.some(
+          (upload) => upload.file.name === file.name,
+        );
+
+        return !isFileAlreadyAdded;
+      });
+
+      const newUploads = uploadsToAdd.map((file) => ({
+        file,
+        progress: 0,
+      }));
+
+      return [...prevUploads, ...newUploads];
+    });
+
+    setIsDropping(false);
   }, []);
 
   function handleDeleteUpload(name: string) {
@@ -50,7 +72,7 @@ export function ImageUpload({
 
   async function handleUpload() {
     try {
-      setIsLoading(true);
+      setIsUploadingFiles(true);
 
       const uploadObjects = await Promise.all(
         uploads.map(async ({ file }) => ({
@@ -92,27 +114,36 @@ export function ImageUpload({
       console.error('Erro ao recuperar as URLs de upload.');
       toast.error('Erro ao recuperar as URLs de upload.');
     } finally {
-      setIsLoading(false);
+      setIsUploadingFiles(false);
     }
   }
 
   return (
     <div className="flex h-full flex-col items-center gap-4">
-      <Dropzone onDrop={onDrop} />
-      <FilesPreview uploads={uploads} onDeleteUpload={handleDeleteUpload} />
+      <Dropzone
+        isUploadingFiles={isUploadingFiles}
+        isDropping={isDropping}
+        onDrop={onDrop}
+      />
+
+      <FilesPreview
+        isUploadingFiles={isUploadingFiles}
+        uploads={uploads}
+        onDeleteUpload={handleDeleteUpload}
+      />
 
       <Button
         className="self-end"
         type="button"
         onClick={handleUpload}
         disabled={
-          isLoading ||
+          isUploadingFiles ||
           !uploads.length ||
           hasSomeInvalidFileType ||
-          uploads.length > 4
+          uploads.length > MAX_FILES
         }
       >
-        {isLoading && <Loader2Icon className="mr-2 animate-spin" />}
+        {isUploadingFiles && <Loader2Icon className="mr-2 animate-spin" />}
         Enviar
       </Button>
     </div>
@@ -121,8 +152,14 @@ export function ImageUpload({
 
 type DropzoneProps = {
   onDrop: (files: Array<File>) => void;
+  isDropping: boolean;
+  isUploadingFiles: boolean;
 };
-export function Dropzone({ onDrop }: DropzoneProps) {
+export function Dropzone({
+  onDrop,
+  isDropping,
+  isUploadingFiles,
+}: DropzoneProps) {
   const { getRootProps, getInputProps, isDragActive } = useDropzone({ onDrop });
 
   return (
@@ -135,21 +172,30 @@ export function Dropzone({ onDrop }: DropzoneProps) {
           rounded-md
           border
           p-2
-          hover:bg-primary-foreground
+          hover:bg-muted
+          transition-all
+          ease-in-out
           md:w-[500px]
         `,
         isDragActive && 'bg-primary-foreground',
+        isUploadingFiles && 'cursor-not-allowed pointer-events-none',
       )}
     >
+      {isDropping ? (
+        <div className="flex h-full flex-col items-center justify-center">
+          <Loader2Icon className="mb-2 size-12 animate-spin" />
+          <h2>Carregando suas fotos</h2>
+        </div>
+      ) : (
+        <div className="flex h-full flex-col items-center justify-center">
+          <PackageOpenIcon className="mb-2 size-12" />
+          <h2>Solte suas fotos aqui</h2>
+          <p className="text-center text-sm text-zinc-500">
+            São permitidos apenas arquivos png e jpeg
+          </p>
+        </div>
+      )}
       <input accept="image/png, image/jpg, image/jpeg" {...getInputProps()} />
-
-      <div className="flex h-full flex-col items-center justify-center">
-        <PackageOpenIcon className="mb-2 size-12" />
-        <h2>Solte suas fotos aqui</h2>
-        <p className="text-center text-sm text-zinc-500">
-          São permitidos apenas arquivos png e jpeg
-        </p>
-      </div>
     </div>
   );
 }
@@ -157,20 +203,30 @@ export function Dropzone({ onDrop }: DropzoneProps) {
 type FilesPreviewProps = {
   uploads: Array<Upload>;
   onDeleteUpload: (name: string) => void;
+  isUploadingFiles: boolean;
 };
 
-function FilesPreview({ uploads, onDeleteUpload }: FilesPreviewProps) {
+function FilesPreview({
+  uploads,
+  isUploadingFiles,
+  onDeleteUpload,
+}: FilesPreviewProps) {
   return (
-    <div className="space-y-2">
+    <div className="space-y-2 shadow-md p-3 rounded-md">
       <span className="text-xl">Arquivos selecionados: {uploads.length}</span>
 
-      {uploads.length > 4 && (
+      {uploads.length > MAX_FILES && (
         <span className="text-sm block text-destructive">
-          O número máximo de arquivos permitidos é 4
+          O número máximo de arquivos permitidos é {MAX_FILES}
         </span>
       )}
 
-      <div className="max-h-80 space-y-2 overflow-y-auto rounded-md p-2">
+      <div
+        className={sanitizeClassName(
+          'max-h-80 space-y-2 overflow-y-auto scrollbar rounded-md p-2',
+          isUploadingFiles && 'pointer-events-none cursor-not-allowed',
+        )}
+      >
         {uploads.map(({ file, progress }) => (
           <FileItem
             key={file.name}
@@ -222,7 +278,7 @@ function FileItem({ file, progress, onDelete }: FileItemProps) {
             className="bg-red-600 px-3 transition-all hover:bg-red-700"
             title="Deletar"
           >
-            <Trash2Icon className="size-4 stroke-primary" />
+            <Trash2Icon className="size-4" />
           </Button>
         </div>
 

--- a/app/dashboard/posts/_components/ImageUpload.tsx
+++ b/app/dashboard/posts/_components/ImageUpload.tsx
@@ -5,9 +5,10 @@ import { useCallback, useMemo, useState } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { toast } from 'sonner';
 
+import { getPresignedURL } from '@/app/actions/getPresignedURL';
 import { Button } from '@/components/ui/Button';
 import { Progress } from '@/components/ui/Progress';
-import { getPresignedURL, uploadFileToS3 } from '@/data/lambda';
+import { uploadFileToS3 } from '@/data/lambda';
 import { sanitizeClassName } from '@/utils/sanitizeClassName';
 import { useRouter } from 'next/navigation';
 

--- a/app/dashboard/posts/layout.tsx
+++ b/app/dashboard/posts/layout.tsx
@@ -12,11 +12,11 @@ type Props = {
 export default async function Layout({ children }: Props) {
   return (
     <section className="flex h-full flex-col space-y-10 flex-1">
-      <div className="flex flex-grow flex-col overflow-y-auto items-center rounded-md border scroolbar p-4 space-y-4 relative">
+      <div className="flex flex-grow flex-col overflow-y-auto items-center rounded-md border scrollbar p-4 space-y-4 relative">
         <Link
           href="/dashboard"
           title="Voltar"
-          className="absolute top-4 left-4"
+          className="absolute top-2 left-2"
         >
           <Button variant="outline">
             <ArrowLeftIcon />

--- a/app/dashboard/profile/edit/action.ts
+++ b/app/dashboard/profile/edit/action.ts
@@ -1,7 +1,8 @@
 'use server';
 
+import { getPresignedURL } from '@/app/actions/getPresignedURL';
 import { createAuthenticationDataSource } from '@/data/authentication';
-import { getPresignedURL, uploadFileToS3 } from '@/data/lambda';
+import { uploadFileToS3 } from '@/data/lambda';
 import { createUserDataSource } from '@/data/user';
 import { password } from '@/models/password';
 import { user } from '@/models/user';

--- a/app/globals.css
+++ b/app/globals.css
@@ -48,16 +48,16 @@
     --ring: 263.4 70% 50.4%;
   }
 
-  .scroolbar::-webkit-scrollbar {
+  .scrollbar::-webkit-scrollbar {
     width: 0.8rem;
     height: 0.8rem;
   }
 
-  .scroolbar::-webkit-scrollbar-track {
+  .scrollbar::-webkit-scrollbar-track {
     background: transparent;
   }
 
-  .scroolbar::-webkit-scrollbar-thumb {
+  .scrollbar::-webkit-scrollbar-thumb {
     background: hsl(var(--ring));
     border-radius: 0.5rem;
     border: 4px solid hsl(var(--background));

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,7 +29,7 @@ export default async function RootLayout({
 
   return (
     <html lang="en" className={theme} style={{ colorScheme: theme }}>
-      <body className="h-screen xl:!px-40 scroolbar bg-gradient-to-b from-background to-background/90 dark:from-background dark:to-background/95">
+      <body className="h-screen xl:!px-40 scrollbar bg-gradient-to-b from-background to-background/90 dark:from-background dark:to-background/95">
         <ThemeProvider
           attribute="class"
           defaultTheme="system"

--- a/components/CmsSidebar.tsx
+++ b/components/CmsSidebar.tsx
@@ -125,7 +125,7 @@ export function CmsSidebar({ className, ...props }: CmsSidebarProps) {
       <li
         className={sanitizeClassName(
           'transition-all',
-          isSelected && 'bg-accent text-blue-600 rounded',
+          isSelected && 'bg-accent text-primary rounded',
         )}
       >
         <Button

--- a/components/CustomBreadcrumb.tsx
+++ b/components/CustomBreadcrumb.tsx
@@ -23,7 +23,7 @@ export function CustomBreadcrumb({ items, progress }: CustomBreadcrumbProps) {
               key={item.label.concat(`-${index}`)}
               className={sanitizeClassName(
                 'flex items-center gap-2',
-                item.finished && 'text-green-500',
+                item.finished && 'text-primary',
                 item.isCurrent && 'font-bold',
               )}
             >

--- a/components/ImageCard.tsx
+++ b/components/ImageCard.tsx
@@ -36,16 +36,16 @@ export function ImageCard({
       <div
         onClick={() => clickable && setIsModalOpen(true)}
         className={sanitizeClassName(
-          'rounded-[20px] shadow w-[258px] md:w-[380px] relative',
+          'rounded-[20px] w-[258px] md:w-[380px] relative',
           className,
         )}
       >
         <CustomTooltip tip={place.name}>
-          <div className="rounded-[20px] border border-[#DCE2E5] transition hover:scale-105 hover:shadow-2xl">
+          <div className="rounded-[20px] border border-[#DCE2E5] transition hover:shadow-md overflow-hidden group">
             <div
               className={sanitizeClassName(
                 'relative',
-                'h-44 md:h-52 w-[258px] md:w-[380px]',
+                'h-44 md:h-52 w-[258px] md:w-[380px] overflow-hidden',
               )}
             >
               <Image
@@ -53,7 +53,7 @@ export function ImageCard({
                 src={place.images[0]}
                 alt={place.name}
                 sizes="100%"
-                className="rounded-t-[20px] object-cover"
+                className="absolute inset-0 rounded-t-[20px] object-cover group-hover:scale-105 transition duration-300"
               />
             </div>
 

--- a/data/lambda.ts
+++ b/data/lambda.ts
@@ -1,23 +1,5 @@
 import axios from 'axios';
 
-import { env } from '@/utils/env';
-
-type GetPresignedURLResponse = {
-  presigned_url: string;
-  file_url: string;
-};
-
-export async function getPresignedURL(file: File) {
-  const { data } = await axios.post<GetPresignedURLResponse>(
-    env.LAMBDA_FUNCTION_URL,
-    {
-      fileName: file.name,
-    },
-  );
-
-  return data;
-}
-
 export async function uploadFileToS3(
   presignedUrl: string,
   file: File,


### PR DESCRIPTION
## Context
Yesterday, I noticed that the "Create Images" page (part of the create post flow) was throwing an error on load.

This PR addresses the root cause of the issue: an attempt to access NODE_ENV on the client side, which is not available in that context.

This issue was likely introduced in PR:
- #190.

## Improvements
In addition to fixing the bug, this PR includes minor UI/UX refinements to enhance the overall user experience.

## Done
- Adjusted scrollbar style typo
- Adjusted styles of `/dashboard/posts/:id` page
- Improved `ImageCard` component hover animation to make it cleaner
- Adjusted old custom `text-primary` properties lost in the codebase
- Improved `ImageUpload` UX by adding loading status and adjusting `onDrop` function
- Fixed the PR core issue by transforming the `getPresignedURL` function into a `server action` (to allow it access NODE_ENV)
- Adjusted `profile photo input`  style in `SignupForm` component


## Preview
[Gravação de tela de 2025-04-25 21-37-50.webm](https://github.com/user-attachments/assets/ed8459c1-24dc-4586-b051-7a2a144b29d0)

