### PR TITLE
Fix/populate tables script

### DIFF
--- a/infra/queries/0-reset-tables.sql
+++ b/infra/queries/0-reset-tables.sql
@@ -1,0 +1,6 @@
+DELETE FROM place_comments;
+DELETE FROM place_ratings;
+DELETE FROM place_images;
+DELETE FROM places;
+DELETE FROM categories;
+DELETE FROM users;

--- a/infra/queries/01-populate-users-table.sql
+++ b/infra/queries/01-populate-users-table.sql
@@ -1,5 +1,3 @@
-DELETE FROM users;
-
 INSERT INTO users
 	(
     email,

--- a/infra/queries/02-populate-categories-table.sql
+++ b/infra/queries/02-populate-categories-table.sql
@@ -1,5 +1,3 @@
-DELETE FROM categories;
-
 INSERT INTO categories
 	(name, is_active)
 VALUES

--- a/infra/queries/03-populate-places-table.sql
+++ b/infra/queries/03-populate-places-table.sql
@@ -1,5 +1,3 @@
-DELETE FROM places;
-
 INSERT INTO places
   (
     name,

--- a/infra/queries/04-populate-places-ratings-table.sql
+++ b/infra/queries/04-populate-places-ratings-table.sql
@@ -1,5 +1,3 @@
-DELETE FROM place_ratings;
-
 WITH approved_places as (
 	SELECT
     id,

--- a/infra/queries/05-populate-places-comments.sql
+++ b/infra/queries/05-populate-places-comments.sql
@@ -1,5 +1,3 @@
-DELETE FROM place_comments;
-
 INSERT INTO place_comments
 	(
     place_id,

--- a/infra/queries/06-populate-places-images-table.sql
+++ b/infra/queries/06-populate-places-images-table.sql
@@ -1,5 +1,3 @@
-DELETE FROM place_images;
-
 INSERT INTO place_images
 	(
     place_id,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "pnpm services:up && pnpm services:wait && pnpm migrate:up && pnpm database:seed && pnpm next",
+    "dev": "pnpm services:up && pnpm services:wait && pnpm database:seed && pnpm next",
     "next": "next dev --turbopack",
     "build": "next build",
     "start": "next start",


### PR DESCRIPTION
## Fix DELETE operation order in orchestrator.populateTables script

The original script was attempting to delete users first, causing errors due to table relationships. To resolve this, I created a separate SQL script that ensures DELETE operations are executed in the correct order, respecting table dependencies.